### PR TITLE
Sqlalchemy 2 refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,5 +54,3 @@ jobs:
         shell: bash
         run: |
           pytest
-        env:
-          SQLALCHEMY_SILENCE_UBER_WARNING: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           # 2019
           - python: 3.8
-            pins: "sqlalchemy==1.3.* alembic==1.8.* geoalchemy2==0.9.*"
+            pins: "sqlalchemy==1.4.0 alembic==1.8.* geoalchemy2==0.9.*"
           # 2021
           - python: 3.9
             pins: "sqlalchemy==1.4.30 alembic==1.8.* geoalchemy2==0.10.*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,17 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: '5.8.0'
+  rev: '5.12.0'
   hooks:
   - id: isort
     exclude: 'settings'
 - repo: https://github.com/psf/black
-  rev: '22.8.0'
+  rev: '23.1.0'
   hooks:
   - id: black
     exclude: 'migrations*|urls*|settings*|setup.py'
 - repo: https://github.com/pycqa/flake8
-  rev: '3.9.2'
+  rev: '6.0.0'
   hooks:
   - id: flake8
     # NB The "exclude" setting in setup.cfg is ignored by pre-commit

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ def get_version():
 
 install_requires = [
     "GeoAlchemy2>=0.9,!=0.11.*",
-    "SQLAlchemy>=1.3,<2",
-    "alembic>=1.8,<2",
+    "SQLAlchemy>=1.3",
+    "alembic>=1.8",
 ]
 
 tests_require = ["pytest", "pytest-cov"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_version():
 
 install_requires = [
     "GeoAlchemy2>=0.9,!=0.11.*",
-    "SQLAlchemy>=1.3",
+    "SQLAlchemy>=1.4",
     "alembic>=1.8",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_version():
 install_requires = [
     "GeoAlchemy2>=0.9,!=0.11.*",
     "SQLAlchemy>=1.4",
-    "alembic>=1.8",
+    "alembic>=1.8,<2",
 ]
 
 tests_require = ["pytest", "pytest-cov"]

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -5,7 +5,7 @@ from alembic.config import Config
 from alembic.environment import EnvironmentContext
 from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
-from sqlalchemy import Column, Integer, MetaData, Table
+from sqlalchemy import Column, Integer, MetaData, Table, text
 from sqlalchemy.exc import IntegrityError
 
 from ..domain import constants, models, views
@@ -43,7 +43,7 @@ def _upgrade_database(db, revision="head", unsafe=True):
             # Speed up by journalling in memory; in case of a crash the database
             # will likely go corrupt.
             # NB: This setting is scoped to this connection.
-            connection.execute("PRAGMA journal_mode = MEMORY")
+            connection.execute(text("PRAGMA journal_mode = MEMORY"))
         config = get_alembic_config(connection)
         alembic_command.upgrade(config, revision)
 

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -56,7 +56,7 @@ class ModelSchema:
         engine = self.db.get_engine()
         if not self.db.has_table("south_migrationhistory"):
             return
-        with engine.connect() as connection:
+        with engine.begin() as connection:
             query = south_migrationhistory.select().order_by(
                 south_migrationhistory.columns["id"].desc()
             )
@@ -68,7 +68,7 @@ class ModelSchema:
 
     def get_version(self):
         """Returns the id (integer) of the latest migration"""
-        with self.db.get_engine().connect() as connection:
+        with self.db.get_engine().begin() as connection:
             context = MigrationContext.configure(
                 connection, opts={"version_table": constants.VERSION_TABLE_NAME}
             )

--- a/threedi_schema/application/threedi_database.py
+++ b/threedi_schema/application/threedi_database.py
@@ -4,7 +4,7 @@ import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
-from sqlalchemy import create_engine, event, inspect
+from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.event import listen
 from sqlalchemy.orm import sessionmaker
@@ -150,13 +150,13 @@ class ThreediDatabase:
             appropriate error.
         """
         session = self.get_session()
-        r = session.execute("select 1")
+        r = session.execute(text("select 1"))
         return r.fetchone()
 
     def check_integrity(self):
         """Should be called before doing anything with an untrusted sqlite file."""
         with self.session_scope() as session:
-            session.execute("PRAGMA integrity_check")
+            session.execute(text("PRAGMA integrity_check"))
 
     def has_table(self, name):
         engine = self.get_engine()

--- a/threedi_schema/domain/models.py
+++ b/threedi_schema/domain/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Boolean, Column, Float, ForeignKey, Integer, String, Text
-from sqlalchemy.orm import relationship, declarative_base
+from sqlalchemy.orm import declarative_base, relationship
 
 from . import constants
 from .custom_types import Geometry, IntegerEnum, VarcharEnum

--- a/threedi_schema/domain/models.py
+++ b/threedi_schema/domain/models.py
@@ -1,6 +1,5 @@
 from sqlalchemy import Boolean, Column, Float, ForeignKey, Integer, String, Text
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, declarative_base
 
 from . import constants
 from .custom_types import Geometry, IntegerEnum, VarcharEnum

--- a/threedi_schema/infrastructure/spatial_index.py
+++ b/threedi_schema/infrastructure/spatial_index.py
@@ -1,5 +1,5 @@
 from geoalchemy2.types import Geometry
-from sqlalchemy import func
+from sqlalchemy import func, text
 
 __all__ = ["ensure_spatial_indexes"]
 
@@ -15,9 +15,9 @@ def _ensure_spatial_index(connection, column):
         return False
 
     idx_name = f"{column.table.name}_{column.name}"
-    connection.execute(f"DROP TABLE IF EXISTS idx_{idx_name}")
+    connection.execute(text(f"DROP TABLE IF EXISTS idx_{idx_name}"))
     for prefix in {"gii_", "giu_", "gid_"}:
-        connection.execute(f"DROP TRIGGER IF EXISTS {prefix}{idx_name}")
+        connection.execute(text(f"DROP TRIGGER IF EXISTS {prefix}{idx_name}"))
     if (
         connection.execute(
             func.CreateSpatialIndex(column.table.name, column.name)
@@ -46,4 +46,4 @@ def ensure_spatial_indexes(db, models):
                 created &= _ensure_spatial_index(connection, geom_columns[0])
 
         if created:
-            connection.execute("VACUUM")
+            connection.execute(text("VACUUM"))

--- a/threedi_schema/infrastructure/spatialite_versions.py
+++ b/threedi_schema/infrastructure/spatialite_versions.py
@@ -7,7 +7,9 @@ __all__ = ["copy_models"]
 
 def get_spatialite_version(db):
     with db.session_scope() as session:
-        ((lib_version,),) = session.execute(text("SELECT spatialite_version()")).fetchall()
+        ((lib_version,),) = session.execute(
+            text("SELECT spatialite_version()")
+        ).fetchall()
 
     # Identify Spatialite version
     inspector = inspect(db.get_engine())

--- a/threedi_schema/infrastructure/spatialite_versions.py
+++ b/threedi_schema/infrastructure/spatialite_versions.py
@@ -1,5 +1,5 @@
 from geoalchemy2.types import Geometry
-from sqlalchemy import func, inspect
+from sqlalchemy import func, inspect, text
 from sqlalchemy.exc import IntegrityError, OperationalError
 
 __all__ = ["copy_models"]
@@ -7,7 +7,7 @@ __all__ = ["copy_models"]
 
 def get_spatialite_version(db):
     with db.session_scope() as session:
-        ((lib_version,),) = session.execute("SELECT spatialite_version()").fetchall()
+        ((lib_version,),) = session.execute(text("SELECT spatialite_version()")).fetchall()
 
     # Identify Spatialite version
     inspector = inspect(db.get_engine())
@@ -32,7 +32,7 @@ def cast_if_geometry(column):
 
 
 def model_count(session, model) -> int:
-    q = f"SELECT COUNT(*) FROM {model.__tablename__}"
+    q = text(f"SELECT COUNT(*) FROM {model.__tablename__}")
     try:
         return session.execute(q).fetchall()[0][0]
     except OperationalError as e:

--- a/threedi_schema/infrastructure/views.py
+++ b/threedi_schema/infrastructure/views.py
@@ -8,7 +8,7 @@ def recreate_views(db, file_version, all_views, views_to_delete):
     engine = db.get_engine()
 
     with engine.begin() as connection:
-        for (name, view) in all_views.items():
+        for name, view in all_views.items():
             connection.execute(text(f"DROP VIEW IF EXISTS {name}"))
             connection.execute(
                 text(f"DELETE FROM views_geometry_columns WHERE view_name = '{name}'")
@@ -16,11 +16,15 @@ def recreate_views(db, file_version, all_views, views_to_delete):
             connection.execute(text(f"CREATE VIEW {name} AS {view['definition']}"))
             if file_version == 3:
                 connection.execute(
-                    text(f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}')")
+                    text(
+                        f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}')"
+                    )
                 )
             else:
                 connection.execute(
-                    text(f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column,read_only) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}', 0)")
+                    text(
+                        f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column,read_only) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}', 0)"
+                    )
                 )
         for name in views_to_delete:
             connection.execute(text(f"DROP VIEW IF EXISTS {name}"))

--- a/threedi_schema/infrastructure/views.py
+++ b/threedi_schema/infrastructure/views.py
@@ -1,3 +1,5 @@
+from sqlalchemy import text
+
 __all__ = ["recreate_views"]
 
 
@@ -7,21 +9,21 @@ def recreate_views(db, file_version, all_views, views_to_delete):
 
     with engine.begin() as connection:
         for (name, view) in all_views.items():
-            connection.execute(f"DROP VIEW IF EXISTS {name}")
+            connection.execute(text(f"DROP VIEW IF EXISTS {name}"))
             connection.execute(
-                f"DELETE FROM views_geometry_columns WHERE view_name = '{name}'"
+                text(f"DELETE FROM views_geometry_columns WHERE view_name = '{name}'")
             )
-            connection.execute(f"CREATE VIEW {name} AS {view['definition']}")
+            connection.execute(text(f"CREATE VIEW {name} AS {view['definition']}"))
             if file_version == 3:
                 connection.execute(
-                    f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}')"
+                    text(f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}')")
                 )
             else:
                 connection.execute(
-                    f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column,read_only) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}', 0)"
+                    text(f"INSERT INTO views_geometry_columns (view_name, view_geometry,view_rowid,f_table_name,f_geometry_column,read_only) VALUES('{name}', '{view['view_geometry']}', '{view['view_rowid']}', '{view['f_table_name']}', '{view['f_geometry_column']}', 0)")
                 )
         for name in views_to_delete:
-            connection.execute(f"DROP VIEW IF EXISTS {name}")
+            connection.execute(text(f"DROP VIEW IF EXISTS {name}"))
             connection.execute(
-                f"DELETE FROM views_geometry_columns WHERE view_name = '{name}'"
+                text(f"DELETE FROM views_geometry_columns WHERE view_name = '{name}'")
             )

--- a/threedi_schema/migrations/versions/0200_initial.py
+++ b/threedi_schema/migrations/versions/0200_initial.py
@@ -7,7 +7,7 @@ Create Date: 2021-02-15 16:31:00.792077
 """
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import inspect
+from sqlalchemy import inspect, text
 
 from threedi_schema.domain.custom_types import Geometry
 
@@ -41,7 +41,7 @@ def _get_version(connection):
     if "south_migrationhistory" not in existing_tables:
         return
     res = connection.execute(
-        "SELECT id FROM south_migrationhistory ORDER BY id DESC LIMIT 1"
+        text("SELECT id FROM south_migrationhistory ORDER BY id DESC LIMIT 1")
     )
     results = res.fetchall()
     if len(results) == 1:
@@ -91,7 +91,7 @@ def upgrade_163():
     with op.batch_alter_table("v2_global_settings") as batch_op:
         batch_op.add_column(sa.Column("use_2d_rain", sa.Integer(), nullable=True))
 
-    op.execute("UPDATE v2_global_settings SET use_2d_rain = 1")
+    op.execute(text("UPDATE v2_global_settings SET use_2d_rain = 1"))
 
 
 def upgrade_164():
@@ -219,7 +219,7 @@ def upgrade_166():
 
     0166_fill_Groundwater_Interflow_SimpleInfiltration
     """
-    op.execute(
+    op.execute(text(
         """
     INSERT INTO v2_interflow (id, interflow_type, porosity, porosity_file, porosity_layer_thickness,
                               impervious_layer_elevation, hydraulic_conductivity, hydraulic_conductivity_file)
@@ -227,8 +227,8 @@ def upgrade_166():
            impervious_layer_elevation, hydraulic_conductivity, hydraulic_conductivity_file
     FROM v2_global_settings;
     """
-    )
-    op.execute(
+    ))
+    op.execute(text(
         """
     INSERT INTO v2_simple_infiltration (id, infiltration_rate, infiltration_rate_file,
                                         infiltration_surface_option, max_infiltration_capacity_file)
@@ -236,10 +236,10 @@ def upgrade_166():
            infiltration_surface_option, max_infiltration_capacity_file
     FROM v2_global_settings;
     """
-    )
-    op.execute(
+    ))
+    op.execute(text(
         """UPDATE v2_global_settings SET interflow_settings_id = id, simple_infiltration_settings_id = id"""
-    )
+    ))
 
 
 def upgrade_167():
@@ -299,12 +299,12 @@ def upgrade_171():
 
     0170_auto__chg_field_v2culvert_discharge_coefficient_negative__chg_field_v2.py
     """
-    op.execute(
+    op.execute(text(
         "UPDATE v2_culvert SET discharge_coefficient_negative = 1.0 WHERE discharge_coefficient_negative IS NULL"
-    )
-    op.execute(
+    ))
+    op.execute(text(
         "UPDATE v2_culvert SET discharge_coefficient_positive = 1.0 WHERE discharge_coefficient_positive IS NULL"
-    )
+    ))
 
 
 def upgrade_172():
@@ -368,7 +368,7 @@ def upgrade():
     # Initialize the Spatialite if necessary:
     if conn.dialect.name == "sqlite" and "spatial_ref_sys" not in existing_tables:
         # The (1) performs the init in 1 transaction, which improves performance.
-        op.execute("SELECT InitSpatialMetadata(1)")
+        op.execute(text("SELECT InitSpatialMetadata(1)"))
 
     version = _get_version(conn)
     if version is not None:

--- a/threedi_schema/migrations/versions/0202_remove_unused_tables.py
+++ b/threedi_schema/migrations/versions/0202_remove_unused_tables.py
@@ -8,7 +8,7 @@ Create Date: 2021-09-29 13:50:19.544275
 import re
 
 from alembic import op
-from sqlalchemy import inspect
+from sqlalchemy import inspect, text
 
 # revision identifiers, used by Alembic.
 revision = "0202"
@@ -104,7 +104,7 @@ def upgrade():
             continue
         defn = inspector.get_view_definition(view_name)
         if VIEW_REGEX.match(defn):
-            op.execute(f"DROP VIEW {view_name}")
+            op.execute(text(f"DROP VIEW {view_name}"))
 
     # then delete the actual tables if they exist
     existing = set(inspector.get_table_names())

--- a/threedi_schema/migrations/versions/0205_settings_defaults.py
+++ b/threedi_schema/migrations/versions/0205_settings_defaults.py
@@ -7,6 +7,8 @@ Create Date: 2021-11-15 16:41:43.316599
 """
 from alembic import op
 
+from sqlalchemy import text
+
 
 # revision identifiers, used by Alembic.
 revision = "0205"
@@ -80,7 +82,7 @@ UPDATE v2_aggregation_settings SET flow_variable = 'discharge'
 
 def upgrade():
     for q in MIGRATION_QUERIES.split(";"):
-        op.execute(q)
+        op.execute(text(q))
 
     with op.batch_alter_table("v2_global_settings") as batch_op:
         batch_op.alter_column("output_time_step", nullable=False)

--- a/threedi_schema/migrations/versions/0206_control_structures.py
+++ b/threedi_schema/migrations/versions/0206_control_structures.py
@@ -7,6 +7,8 @@ Create Date: 2021-12-16 13:30:00
 """
 from alembic import op
 
+from sqlalchemy import text
+
 # revision identifiers, used by Alembic.
 revision = "0206"
 down_revision = "0205"
@@ -21,7 +23,7 @@ UPDATE v2_control_measure_map SET weight = 1.0 WHERE weight IS NULL;
 
 def upgrade():
     for q in MIGRATION_QUERIES.split(";"):
-        op.execute(q)
+        op.execute(text(q))
 
     with op.batch_alter_table("v2_control_measure_map") as batch_op:
         batch_op.alter_column("object_id", nullable=False)

--- a/threedi_schema/migrations/versions/0206_control_structures.py
+++ b/threedi_schema/migrations/versions/0206_control_structures.py
@@ -6,7 +6,6 @@ Create Date: 2021-12-16 13:30:00
 
 """
 from alembic import op
-
 from sqlalchemy import text
 
 # revision identifiers, used by Alembic.

--- a/threedi_schema/migrations/versions/0210_global_raster_values.py
+++ b/threedi_schema/migrations/versions/0210_global_raster_values.py
@@ -26,7 +26,7 @@ UPDATE v2_groundwater SET groundwater_hydro_connectivity = NULL WHERE groundwate
 
 def upgrade():
     for q in MIGRATION_QUERIES.split(";"):
-        op.execute(q)
+        op.execute(sa.text(q))
 
     with op.batch_alter_table("v2_simple_infiltration") as batch_op:
         batch_op.add_column(

--- a/threedi_schema/migrations/versions/0213_connected_points_to_breaches.py
+++ b/threedi_schema/migrations/versions/0213_connected_points_to_breaches.py
@@ -9,8 +9,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Float, ForeignKey, func, Integer, String
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, declarative_base
 
 from threedi_schema.domain.custom_types import Geometry
 

--- a/threedi_schema/migrations/versions/0213_connected_points_to_breaches.py
+++ b/threedi_schema/migrations/versions/0213_connected_points_to_breaches.py
@@ -9,7 +9,7 @@ import logging
 
 from alembic import op
 from sqlalchemy import Column, Float, ForeignKey, func, Integer, String
-from sqlalchemy.orm import Session, declarative_base
+from sqlalchemy.orm import declarative_base, Session
 
 from threedi_schema.domain.custom_types import Geometry
 

--- a/threedi_schema/migrations/versions/0214_drop_cpoints_levees.py
+++ b/threedi_schema/migrations/versions/0214_drop_cpoints_levees.py
@@ -27,10 +27,10 @@ INSERT INTO v2_levee (code, crest_level, the_geom) SELECT code, crest_level, the
 
 
 def upgrade():
-    op.execute(LEVEE_TO_OBSTACLE)
+    op.execute(sa.text(LEVEE_TO_OBSTACLE))
 
     for table_name in ["v2_connected_pnt", "v2_calculation_point", "v2_levee"]:
-        op.execute(f"SELECT DropGeoTable('{table_name}')")
+        op.execute(sa.text(f"SELECT DropGeoTable('{table_name}')"))
 
 
 def downgrade():

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -55,7 +55,7 @@ def test_get_version_empty_south(in_memory_sqlite, south_migration_table):
 
 def test_get_version_south(in_memory_sqlite, south_migration_table):
     """Get the version of a sqlite with a South version table"""
-    with in_memory_sqlite.get_engine().connect() as connection:
+    with in_memory_sqlite.get_engine().begin() as connection:
         for v in (42, 43):
             connection.execute(south_migration_table.insert().values(id=v))
 
@@ -73,7 +73,7 @@ def test_get_version_empty_alembic(in_memory_sqlite, alembic_version_table):
 
 def test_get_version_alembic(in_memory_sqlite, alembic_version_table):
     """Get the version of a sqlite with an alembic version table"""
-    with in_memory_sqlite.get_engine().connect() as connection:
+    with in_memory_sqlite.get_engine().begin() as connection:
         connection.execute(alembic_version_table.insert().values(version_num="0201"))
 
     schema_checker = ModelSchema(in_memory_sqlite)

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from sqlalchemy import Column, Integer, MetaData, String, Table
+from sqlalchemy import Column, Integer, MetaData, String, Table, text
 
 from threedi_schema import ModelSchema
 from threedi_schema.application import errors
@@ -181,7 +181,7 @@ def test_set_views(oldest_sqlite):
     # Test all views
     with oldest_sqlite.session_scope() as session:
         for view_name in ALL_VIEWS:
-            session.execute(f"SELECT * FROM {view_name} LIMIT 1").fetchall()
+            session.execute(text(f"SELECT * FROM {view_name} LIMIT 1")).fetchall()
 
 
 def test_upgrade_spatialite_3(oldest_sqlite):
@@ -198,7 +198,7 @@ def test_upgrade_spatialite_3(oldest_sqlite):
     # the spatial indexes are there
     with oldest_sqlite.get_engine().begin() as connection:
         check_result = connection.execute(
-            "SELECT CheckSpatialIndex('v2_connection_nodes', 'the_geom')"
+            text("SELECT CheckSpatialIndex('v2_connection_nodes', 'the_geom')")
         ).scalar()
 
     assert check_result == 1
@@ -212,15 +212,15 @@ def test_set_spatial_indexes(in_memory_sqlite):
 
     with engine.begin() as connection:
         connection.execute(
-            "SELECT DisableSpatialIndex('v2_connection_nodes', 'the_geom')"
+            text("SELECT DisableSpatialIndex('v2_connection_nodes', 'the_geom')")
         ).scalar()
-        connection.execute("DROP TABLE idx_v2_connection_nodes_the_geom")
+        connection.execute(text("DROP TABLE idx_v2_connection_nodes_the_geom"))
 
     schema.set_spatial_indexes()
 
     with engine.begin() as connection:
         check_result = connection.execute(
-            "SELECT CheckSpatialIndex('v2_connection_nodes', 'the_geom')"
+            text("SELECT CheckSpatialIndex('v2_connection_nodes', 'the_geom')")
         ).scalar()
 
     assert check_result == 1


### PR DESCRIPTION
This pull request refactors the codebase to make it support SQLAlchemy 2.0. The refactor should also allow removing `SQLALCHEMY_SILENCE_UBER_WARNING: 1` from the test environment, both in this repo and in dependent repos with warnings caused by this repo.