### PR TITLE
Fix DROP TABLE for v2_levee and others

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog of threedi-schema
 0.216.3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fixed DROP TABLE in migration 214 (tables "v2_connected_pnt", "v2_calculation_point",
+  "v2_levee" remained present). The DROP TABLE is emitted again in migration 216.
 
 
 0.216.2 (2023-03-24)

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ profile = black
 force_alphabetical_sort_within_sections = true
 
 [tool:pytest]
-addopts = --cov --cache-clear threedi_schema
+addopts = --cov --cache-clear
 norecursedirs = .venv data doc etc *.egg-info misc var build lib include
 python_files = test_*.py
 testpaths =

--- a/threedi_schema/migrations/versions/0214_drop_cpoints_levees.py
+++ b/threedi_schema/migrations/versions/0214_drop_cpoints_levees.py
@@ -30,7 +30,7 @@ def upgrade():
     op.execute(sa.text(LEVEE_TO_OBSTACLE))
 
     for table_name in ["v2_connected_pnt", "v2_calculation_point", "v2_levee"]:
-        op.execute(sa.text(f"SELECT DropGeoTable('{table_name}')"))
+        op.execute(sa.text(f"SELECT DropTable(NULL, '{table_name}')"))
 
 
 def downgrade():

--- a/threedi_schema/migrations/versions/0216_vegetation_drag.py
+++ b/threedi_schema/migrations/versions/0216_vegetation_drag.py
@@ -33,6 +33,10 @@ def upgrade():
 
     op.add_column('v2_global_settings', sa.Column('vegetation_drag_settings_id', sa.Integer(), nullable=True))
 
+    ## FIX migration 214:
+    for table_name in ["v2_connected_pnt", "v2_calculation_point", "v2_levee"]:
+        op.execute(sa.text(f"SELECT DropTable(NULL, '{table_name}', TRUE)"))
+
 
 def downgrade():
     op.drop_constraint(None, 'v2_global_settings', type_='foreignkey')

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -120,6 +120,8 @@ def test_full_upgrade_with_preexisting_version(south_latest_sqlite):
     schema.upgrade(backup=False, set_views=False, upgrade_spatialite_version=False)
     assert schema.get_version() == get_schema_version()
     assert south_latest_sqlite.has_table("v2_connection_nodes")
+    # https://github.com/nens/threedi-schema/issues/10:
+    assert not south_latest_sqlite.has_table("v2_levee")
 
 
 def test_full_upgrade_oldest(oldest_sqlite):
@@ -128,6 +130,8 @@ def test_full_upgrade_oldest(oldest_sqlite):
     schema.upgrade(backup=False, set_views=False, upgrade_spatialite_version=False)
     assert schema.get_version() == get_schema_version()
     assert oldest_sqlite.has_table("v2_connection_nodes")
+    # https://github.com/nens/threedi-schema/issues/10:
+    assert not oldest_sqlite.has_table("v2_levee")
 
 
 def test_upgrade_south_not_latest_errors(in_memory_sqlite):


### PR DESCRIPTION
Apparently the DropGeoTable (which was used previously) didn't work.

In the docs (https://www.gaia-gis.it/gaia-sins/spatialite-sql-5.0.1.html); DropTable() is now recommended. When switching to that the v2_levee disappeared. I appended this DropTable to migration 216, to fix situations where migration 214 already ran. There is no client application using 216 already so I this approach that is fine.