### PR TITLE
rename vegetation column names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of threedi-schema
 0.216.5 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Rename vegetation columns to match raster options.
 
 
 0.216.4 (2023-04-11)

--- a/threedi_schema/domain/models.py
+++ b/threedi_schema/domain/models.py
@@ -366,16 +366,16 @@ class VegetationDrag(Base):
     display_name = Column(String(255))
 
     height = Column(Float)
-    height_file = Column(String(255))
+    vegetation_height_file = Column(String(255))
 
     stem_count = Column(Float)
-    stem_count_file = Column(String(255))
+    vegetation_stem_count_file = Column(String(255))
 
     stem_diameter = Column(Float)
-    stem_diameter_file = Column(String(255))
+    vegetation_stem_diameter_file = Column(String(255))
 
     drag_coefficient = Column(Float)
-    drag_coefficient_file = Column(String(255))
+    vegetation_drag_coefficient_file = Column(String(255))
 
     global_settings = relationship(
         "GlobalSetting", back_populates="vegetation_drag_settings"

--- a/threedi_schema/domain/models.py
+++ b/threedi_schema/domain/models.py
@@ -365,16 +365,16 @@ class VegetationDrag(Base):
     id = Column(Integer, primary_key=True)
     display_name = Column(String(255))
 
-    height = Column(Float)
+    vegetation_height = Column(Float)
     vegetation_height_file = Column(String(255))
 
-    stem_count = Column(Float)
+    vegetation_stem_count = Column(Float)
     vegetation_stem_count_file = Column(String(255))
 
-    stem_diameter = Column(Float)
+    vegetation_stem_diameter = Column(Float)
     vegetation_stem_diameter_file = Column(String(255))
 
-    drag_coefficient = Column(Float)
+    vegetation_drag_coefficient = Column(Float)
     vegetation_drag_coefficient_file = Column(String(255))
 
     global_settings = relationship(

--- a/threedi_schema/migrations/versions/0217_rename_vegetation_columns.py
+++ b/threedi_schema/migrations/versions/0217_rename_vegetation_columns.py
@@ -7,7 +7,6 @@ Create Date: 2023-05-05 11:52:34.238859
 """
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision = '0217'
 down_revision = '0216'

--- a/threedi_schema/migrations/versions/0217_rename_vegetation_columns.py
+++ b/threedi_schema/migrations/versions/0217_rename_vegetation_columns.py
@@ -1,0 +1,47 @@
+"""rename vegetation columns
+
+Revision ID: 0217
+Revises: 0216
+Create Date: 2023-05-05 11:52:34.238859
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '0217'
+down_revision = '0216'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("v2_vegetation_drag") as batch_op:
+        batch_op.alter_column(
+            "height_file", new_column_name="vegetation_height_file"
+        )
+        batch_op.alter_column(
+            "stem_count_file", new_column_name="vegetation_stem_count_file"
+        )
+        batch_op.alter_column(
+            "stem_diameter_file", new_column_name="vegetation_stem_diameter_file"
+        )
+        batch_op.alter_column(
+            "drag_coefficient_file", new_column_name="vegetation_drag_coefficient_file"
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("v2_vegetation_drag") as batch_op:
+        batch_op.alter_column(
+            "vegetation_height_file", new_column_name="height_file"
+        )
+        batch_op.alter_column(
+            "vegetation_stem_count_file", new_column_name="stem_count_file"
+        )
+        batch_op.alter_column(
+            "vegetation_stem_diameter_file", new_column_name="stem_diameter_file"
+        )
+        batch_op.alter_column(
+            "vegetation_drag_coefficient_file", new_column_name="drag_coefficient_file"
+        )

--- a/threedi_schema/migrations/versions/0217_rename_vegetation_columns.py
+++ b/threedi_schema/migrations/versions/0217_rename_vegetation_columns.py
@@ -17,13 +17,25 @@ depends_on = None
 def upgrade():
     with op.batch_alter_table("v2_vegetation_drag") as batch_op:
         batch_op.alter_column(
+            "height", new_column_name="vegetation_height"
+        )
+        batch_op.alter_column(
             "height_file", new_column_name="vegetation_height_file"
+        )
+        batch_op.alter_column(
+            "stem_count", new_column_name="vegetation_stem_count"
         )
         batch_op.alter_column(
             "stem_count_file", new_column_name="vegetation_stem_count_file"
         )
         batch_op.alter_column(
+            "stem_diameter", new_column_name="vegetation_stem_diameter"
+        )
+        batch_op.alter_column(
             "stem_diameter_file", new_column_name="vegetation_stem_diameter_file"
+        )
+        batch_op.alter_column(
+            "drag_coefficient", new_column_name="vegetation_drag_coefficient"
         )
         batch_op.alter_column(
             "drag_coefficient_file", new_column_name="vegetation_drag_coefficient_file"
@@ -33,13 +45,25 @@ def upgrade():
 def downgrade():
     with op.batch_alter_table("v2_vegetation_drag") as batch_op:
         batch_op.alter_column(
+            "vegetation_height", new_column_name="height"
+        )
+        batch_op.alter_column(
             "vegetation_height_file", new_column_name="height_file"
+        )
+        batch_op.alter_column(
+            "vegetation_stem_count", new_column_name="stem_count"
         )
         batch_op.alter_column(
             "vegetation_stem_count_file", new_column_name="stem_count_file"
         )
         batch_op.alter_column(
+            "vegetation_stem_diameter", new_column_name="stem_diameter"
+        )
+        batch_op.alter_column(
             "vegetation_stem_diameter_file", new_column_name="stem_diameter_file"
+        )
+        batch_op.alter_column(
+            "vegetation_drag_coefficient", new_column_name="drag_coefficient"
         )
         batch_op.alter_column(
             "vegetation_drag_coefficient_file", new_column_name="drag_coefficient_file"


### PR DESCRIPTION
Raster options and threedi schema column names dont match so this migration tries to fix that. As the previous schema already has been released we need a whole new migration I think. But let me know if this in incorrect or something else is missing.