### PR TITLE
31 bug setting views fails when migrating from 208 to 217

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog of threedi-schema
 0.217.7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Don't set journal_mode to MEMORY since it causes the schema version
+  field to not be updated, making migrations crash.
 
 
 0.217.6 (2023-07-13)

--- a/threedi_schema/migrations/env.py
+++ b/threedi_schema/migrations/env.py
@@ -35,11 +35,14 @@ def run_migrations_online():
     
 
     with engine.connect() as connection:
-        if unsafe:
-            # Speed up by journalling in memory; in case of a crash the database
-            # will likely go corrupt.
-            # NB: This setting is scoped to this connection.
-            connection.execute(text("PRAGMA journal_mode = MEMORY"))
+        # the following 5 lines have been commented out because for some reason the
+        # spatialite schema_version doesn't get updated when journal_mode is set to MEMORY
+        # TODO: make this work again.
+        # if unsafe:
+        #     # Speed up by journalling in memory; in case of a crash the database
+        #     # will likely go corrupt.
+        #     # NB: This setting is scoped to this connection.
+        #     connection.execute(text("PRAGMA journal_mode = MEMORY"))
 
         context.configure(
             connection=connection,


### PR DESCRIPTION
This PR no longer sets journal_mode to MEMORY since it causes the schema version field to not be updated, making migrations crash.