### PR TITLE
Make friction_value in CrossSectionLocation table nullable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changelog of threedi-schema
 ===================================================
 
-0.218.1 (unreleased)
+0.219.0 (2024-01-25)
 --------------------
 
-- Nothing changed yet.
+- Make CrossSectionLocation.friction_value nullable
 
 
 0.218.0 (2024-01-08)

--- a/threedi_schema/domain/models.py
+++ b/threedi_schema/domain/models.py
@@ -576,7 +576,7 @@ class CrossSectionLocation(Base):
     code = Column(String(100))
     reference_level = Column(Float, nullable=False)
     friction_type = Column(IntegerEnum(constants.FrictionType), nullable=False)
-    friction_value = Column(Float, nullable=False)
+    friction_value = Column(Float)
     bank_level = Column(Float)
     vegetation_stem_density = Column(Float)
     vegetation_stem_diameter = Column(Float)

--- a/threedi_schema/migrations/versions/0219_nullable_cross_section_location_friction_value.py
+++ b/threedi_schema/migrations/versions/0219_nullable_cross_section_location_friction_value.py
@@ -1,8 +1,8 @@
 """rename vegetation columns
 
-Revision ID: 0218
-Revises: 0217
-Create Date: 2023-12-22 08:33
+Revision ID: 0219
+Revises: 0218
+Create Date: 2024-01-22 15:00
 
 """
 
@@ -15,7 +15,18 @@ down_revision = '0218'
 branch_labels = None
 depends_on = None
 
+MIGRATION_QUERIES = """
+SELECT RecoverGeometryColumn('v2_cross_section_location', 'the_geom', 4326, 'POINT', 'XY')
+"""
+
 
 def upgrade():
     with op.batch_alter_table("v2_cross_section_location") as batch_op:
-        batch_op.alter_column("friction_value", nullable=True, type_=sa.TEXT)
+        batch_op.alter_column("friction_value", nullable=True, type_=sa.Float)
+    for q in MIGRATION_QUERIES.split(";"):
+        op.execute(sa.text(q))
+
+
+def downgrade():
+    with op.batch_alter_table("v2_cross_section_location") as batch_op:
+        batch_op.alter_column("friction_value", nullable=False, type_=sa.Float)

--- a/threedi_schema/migrations/versions/0219_nullable_cross_section_location_friction_value.py
+++ b/threedi_schema/migrations/versions/0219_nullable_cross_section_location_friction_value.py
@@ -1,0 +1,21 @@
+"""rename vegetation columns
+
+Revision ID: 0218
+Revises: 0217
+Create Date: 2023-12-22 08:33
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '0219'
+down_revision = '0218'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("v2_cross_section_location") as batch_op:
+        batch_op.alter_column("friction_value", nullable=True, type_=sa.TEXT)


### PR DESCRIPTION
`CrossSectionDefinition.friction_values` can be present *instead* of `CrossSectionLocation.friction_value`. However, all nullable columns are automatically checked in https://github.com/nens/threedi-modelchecker/blob/master/threedi_modelchecker/config.py#L41. So to allow for the situation where `CrossSectionLocation.friction_value` is `None` and `CrossSectionDefinition.friction_values` is defined, `CrossSectionLocation.friction_value` needs to become nullable.

The changes in the modelchecker related to this are here: https://github.com/nens/threedi-modelchecker/pull/353/commits/70f93938dcd79f556c8f96a7e5ad62207cc8980d