### PR TITLE
Disable geopackage conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of threedi-schema
 0.222.1 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Disable `convert_to_geopackage` in `schema.upgrade` for schema version before 300
+- Ensure `revision` format in `schema.upgrade` is correctly formatted
 
 
 0.222.0 (2024-05-22)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -120,12 +120,10 @@ class ModelSchema:
                 f"Incorrect version format: {revision}. Expected 'head' or a numeric value."
             )
         if convert_to_geopackage and rev_nr < 300:
-            warnings.warn(
-                "Cannot convert to geopackage for revision {=revision.str} because geopackage support is "
+            raise UpgradeFailedError(
+                f"Cannot convert to geopackage for {revision=} because geopackage support is "
                 "enabled from revision 300",
-                UserWarning,
             )
-            convert_to_geopackage = False
         if upgrade_spatialite_version and not set_views:
             set_views = True
             warnings.warn(

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -113,6 +113,19 @@ class ModelSchema:
         Specify 'convert_to_geopackage=True' to also convert from spatialite
         to geopackage file version after the upgrade.
         """
+        try:
+            rev_nr = get_schema_version() if revision == "head" else int(revision)
+        except ValueError:
+            raise ValueError(
+                f"Incorrect version format: {revision}. Expected 'head' or a numeric value."
+            )
+        if convert_to_geopackage and rev_nr < 300:
+            warnings.warn(
+                "Cannot convert to geopackage for revision {=revision.str} because geopackage support is "
+                "enabled from revision 300",
+                UserWarning,
+            )
+            convert_to_geopackage = False
         if upgrade_spatialite_version and not set_views:
             set_views = True
             warnings.warn(

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -211,11 +211,11 @@ def test_set_views_warning(oldest_sqlite):
         schema.upgrade(backup=False, set_views=False, upgrade_spatialite_version=True)
 
 
-def test_convert_to_geopackage_warning(oldest_sqlite):
+def test_convert_to_geopackage_raise(oldest_sqlite):
     if get_schema_version() >= 300:
         pytest.skip("Warning not expected beyond schema 300")
     schema = ModelSchema(oldest_sqlite)
-    with pytest.warns(UserWarning):
+    with pytest.raises(errors.UpgradeFailedError):
         schema.upgrade(
             backup=False,
             set_views=False,

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -181,26 +181,21 @@ def test_upgrade_without_backup(south_latest_sqlite):
 
 
 @pytest.mark.parametrize(
-    "set_views, upgrade_spatialite_version, convert_to_geopackage",
+    "set_views, upgrade_spatialite_version",
     [
-        (True, False, False),
-        (False, True, False),
-        (True, True, False),
-        (True, False, True),
-        (False, False, True),
+        (True, False),
+        (False, True),
+        (True, True),
     ],
 )
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_set_views(
-    oldest_sqlite, set_views, upgrade_spatialite_version, convert_to_geopackage
-):
+def test_set_views(oldest_sqlite, set_views, upgrade_spatialite_version):
     """Make sure that the views are regenerated"""
     schema = ModelSchema(oldest_sqlite)
     schema.upgrade(
         backup=False,
         set_views=set_views,
         upgrade_spatialite_version=upgrade_spatialite_version,
-        convert_to_geopackage=convert_to_geopackage,
     )
     assert schema.get_version() == get_schema_version()
 
@@ -214,6 +209,25 @@ def test_set_views_warning(oldest_sqlite):
     schema = ModelSchema(oldest_sqlite)
     with pytest.warns(UserWarning):
         schema.upgrade(backup=False, set_views=False, upgrade_spatialite_version=True)
+
+
+def test_convert_to_geopackage_warning(oldest_sqlite):
+    if get_schema_version() >= 300:
+        pytest.skip("Warning not expected beyond schema 300")
+    schema = ModelSchema(oldest_sqlite)
+    with pytest.warns(UserWarning):
+        schema.upgrade(
+            backup=False,
+            set_views=False,
+            upgrade_spatialite_version=False,
+            convert_to_geopackage=True,
+        )
+
+
+def test_upgrade_revision_exception(oldest_sqlite):
+    schema = ModelSchema(oldest_sqlite)
+    with pytest.raises(ValueError):
+        schema.upgrade(revision="foo")
 
 
 def test_upgrade_spatialite_3(oldest_sqlite):


### PR DESCRIPTION
To prevent issues with the schema migration is disabled for any schema version < 300