### PR TITLE
Revert removal of customized load_spatialite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.224.1 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Revert removing on customized load_spatialite function
 
 
 0.224.0 (2024-08-16)

--- a/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
+++ b/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
@@ -11,11 +11,11 @@ from typing import Dict, List, Tuple
 
 import sqlalchemy as sa
 from alembic import op
-from geoalchemy2 import load_spatialite
 from sqlalchemy import Boolean, Column, Float, Integer, String, Text
 from sqlalchemy.event import listen
 from sqlalchemy.orm import declarative_base
 
+from threedi_schema.application.threedi_database import load_spatialite
 from threedi_schema.domain.custom_types import Geometry
 
 # revision identifiers, used by Alembic.

--- a/threedi_schema/migrations/versions/0224_db_upgrade_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_db_upgrade_structure_control.py
@@ -9,9 +9,7 @@ from typing import Dict, List, Tuple
 
 import sqlalchemy as sa
 from alembic import op
-from geoalchemy2 import load_spatialite
 from sqlalchemy import Boolean, Column, Float, Integer, String, Text
-from sqlalchemy.event import listen
 from sqlalchemy.orm import declarative_base
 
 from threedi_schema.domain.custom_types import Geometry


### PR DESCRIPTION
Removed too much code when adding geopackage support in https://github.com/nens/threedi-schema/pull/55. Which broke the migration on windows machines. So re-added the custom `load_spatialite` functionality and used that in the migration. Leendert has tested this code (`pip install threedi-schema==0.224.1.dev0`) and confirmed this resolved the problem.

This will need some fixing once geopackage support is re-added, but I rather do that then so it can be properly tested.