### PR TITLE
Fix 91

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.224.5 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Do not migrate controls that refer to non-existing nodes
 
 
 0.224.4 (2024-09-23)

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -6,6 +6,7 @@ Create Date: 2024-06-30 14:50
 
 """
 import uuid
+import warnings
 from typing import Dict, List, Tuple
 
 import sqlalchemy as sa
@@ -72,6 +73,10 @@ ADD_TABLES = {
 }
 
 
+class InvalidConnectionNode(UserWarning):
+    pass
+
+
 def create_new_tables(new_tables: Dict[str, sa.Column]):
     # no checks for existence are done, this will fail if any table already exists
     for table_name, columns in new_tables.items():
@@ -113,12 +118,20 @@ def move_setting(src_table: str, src_col: str, dst_table: str, dst_col: str):
 
 
 def remove_invalid_rows_from_v2_control_measure_map():
-    op.execute(sa.text("""
-    DELETE FROM v2_control_measure_map
+    conn = op.get_bind()
+    where_clause = """
     WHERE object_id NOT IN (
-        SELECT id FROM v2_connection_nodes
-    );    
-    """))
+        SELECT id FROM v2_connection_nodes WHERE the_geom IS NOT NULL
+    )
+    """
+    invalid_rows = conn.execute(sa.text(f"SELECT id FROM v2_control_measure_map {where_clause};")).fetchall()
+    if len(invalid_rows) > 0:
+        op.execute(sa.text(f"DELETE FROM v2_control_measure_map {where_clause};"))
+        msg = (f"Could not migrate the following rows from v2_control_measure_map because "
+               f"they are linked to connection nodes that do not exist"
+               f"or have no geometry: {invalid_rows}")
+        warnings.warn(msg, InvalidConnectionNode)
+
 
 
 def remove_orphan_control(table_name):


### PR DESCRIPTION
Prevent migration of control_measure_map rows that refer to a connection node that doesn't exist, or has no geometry.