### PR TITLE
Fix structure control geometries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog of threedi-schema
 
 - Swap start and end of control_measure_map geometries
 - Modify geometry of controls associated with pumpstation to the pumpstation start node
+- Ensure control_measure_map.geom is a valid line
 
 
 0.224.6 (2024-09-25)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of threedi-schema
 0.224.7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Swap start and end of control_measure_map geometries
+- Modify geometry of controls associated with pumpstation to the pumpstation start node
 
 
 0.224.6 (2024-09-25)

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -196,7 +196,18 @@ def add_control_geometries(control_name):
         op.execute(sa.text(query))
 
 
+def get_global_srid():
+    conn = op.get_bind()
+    use_0d_inflow = conn.execute(sa.text("SELECT use_0d_inflow FROM simulation_template_settings LIMIT 1")).fetchone()
+    if use_0d_inflow is not None:
+        srid = conn.execute(sa.text("SELECT epsg_code FROM model_settings LIMIT 1")).fetchone()
+        if (srid is not None) and (srid[0] is not None):
+            return srid[0]
+    return 28992
+
+
 def set_geom_for_control_measure_map():
+    srid = get_global_srid()
     for control in ['memory', 'table']:
         control_table = f'{control}_control'
         query = f"""
@@ -204,8 +215,22 @@ def set_geom_for_control_measure_map():
             control_measure_map
         SET
             geom = (
-                SELECT 
-                    MakeLine(cml.geom, tc.geom)
+                SELECT CASE
+                    WHEN ST_Equals(cml.geom, tc.geom) THEN
+                        -- Transform to EPSG:4326 for the projection, then back to the original SRID
+                        MakeLine(
+                            cml.geom,
+                            PointOnSurface(ST_Transform(
+                                ST_Translate(
+                                    ST_Transform(tc.geom, {srid}),
+                                    0, 1, 0
+                                ),
+                                4326
+                            ))                       
+                        )
+                    ELSE
+                        MakeLine(cml.geom, tc.geom)
+                    END                                           
                 FROM 
                     {control_table} AS tc
                 JOIN 

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -171,7 +171,7 @@ def set_geom_for_control_measure_map():
         SET
             geom = (
                 SELECT 
-                    MakeLine(tc.geom, cml.geom)
+                    MakeLine(cml.geom, tc.geom)
                 FROM 
                     {control_table} AS tc
                 JOIN 

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -220,13 +220,13 @@ def set_geom_for_control_measure_map():
                         -- Transform to EPSG:4326 for the projection, then back to the original SRID
                         MakeLine(
                             cml.geom,
-                            PointOnSurface(ST_Transform(
+                            ST_Transform(
                                 ST_Translate(
                                     ST_Transform(tc.geom, {srid}),
                                     0, 1, 0
                                 ),
                                 4326
-                            ))                       
+                            )                   
                         )
                     ELSE
                         MakeLine(cml.geom, tc.geom)

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -166,6 +166,12 @@ def add_control_geometries(control_name):
                 FROM v2_culvert AS object
                 JOIN v2_cross_section_definition AS def ON object.cross_section_definition_id = def.id
             """
+        elif target_type == 'v2_pumpstation':
+            geom_query = f"""
+                SELECT start_node.the_geom
+                FROM {target_type} AS object   
+                JOIN v2_connection_nodes AS start_node ON object.connection_node_start_id = start_node.id
+            """
         else:
             geom_query = f"""
                 SELECT ST_Centroid(MakeLine(start_node.the_geom, end_node.the_geom))


### PR DESCRIPTION
- Swap start and end of control_measure_map geometries
- Modify geometry of controls associated with pumpstation to the pumpstation start node
- Ensure control_measure_map.geom is a valid line