### PR TITLE
Prevent migrations 222 to 224 from failing when conflicting table names exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.224.7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Prevent migration 222 to 224 from failing when any of the new table names already exists
 
 
 0.224.6 (2024-09-25)

--- a/threedi_schema/migrations/versions/0222_upgrade_db_settings.py
+++ b/threedi_schema/migrations/versions/0222_upgrade_db_settings.py
@@ -350,10 +350,18 @@ def set_flow_variable_values():
     op.execute(sa.text(query))
 
 
+def drop_conflicting():
+    new_tables = list(ADD_TABLES.keys()) + [new_name for _, new_name in RENAME_TABLES]
+    for table_name in new_tables:
+        op.execute(f"DROP TABLE IF EXISTS {table_name};")
+
+
 def upgrade():
     op.get_bind()
     # Only use first row of global settings
     delete_all_but_first_row("v2_global_settings")
+    # Remove existing tables (outside of the specs) that conflict with new table names
+    drop_conflicting()
     rename_tables(RENAME_TABLES)
     # rename columns in renamed tables
     for table_name, columns in RENAME_COLUMNS.items():

--- a/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
+++ b/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
@@ -484,9 +484,17 @@ def fix_geometry_columns():
         op.execute(sa.text(migration_query))
 
 
+def drop_conflicting():
+    new_tables = list(ADD_TABLES.keys()) + [new_name for _, new_name in RENAME_TABLES]
+    for table_name in new_tables:
+        op.execute(f"DROP TABLE IF EXISTS {table_name};")
+
+
 def upgrade():
     connection = op.get_bind()
     listen(connection.engine, "connect", load_spatialite)
+    # Remove existing tables (outside of the specs) that conflict with new table names
+    drop_conflicting()
     # create new tables and rename existing tables
     create_new_tables(ADD_TABLES)
     rename_tables(RENAME_TABLES)

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -339,7 +339,15 @@ def fix_geometry_columns():
         op.execute(sa.text(migration_query))
 
 
+def drop_conflicting():
+    new_tables = list(ADD_TABLES.keys()) + [new_name for _, new_name in RENAME_TABLES]
+    for table_name in new_tables:
+        op.execute(f"DROP TABLE IF EXISTS {table_name};")
+
+
 def upgrade():
+    # Remove existing tables (outside of the specs) that conflict with new table names
+    drop_conflicting()
     # create new tables and rename existing tables
     create_new_tables(ADD_TABLES)
     rename_tables(RENAME_TABLES)


### PR DESCRIPTION
Schematisations may already contain any of the table names that are in the new schematisation. To prevent conflicts, I added a step to drop those at the beginning of each migration. 

I made this a hotfix for 224 because this could potentially break a migration on production.