### PR TITLE
Change name of table tags to tag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog of threedi-schema
 0.228.1 (unreleased)
 --------------------
 
+- Rename sqlite table "tags" to "tag"
+
 
 0.228.0 (unreleased)
 --------------------

--- a/threedi_schema/domain/models.py
+++ b/threedi_schema/domain/models.py
@@ -686,7 +686,7 @@ class ExchangeLine(Base):
 
 
 class Tags(Base):
-    __tablename__ = "tags"
+    __tablename__ = "tag"
     id = Column(Integer, primary_key=True)
     description = Column(Text)
 

--- a/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
+++ b/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
@@ -77,7 +77,7 @@ ADD_TABLES = {
         Column("tags", Text),
         Column("distribution", Text)
     ],
-    "tags": [
+    "tag": [
         Column("description", Text)
     ]
 }

--- a/threedi_schema/tests/test_migration.py
+++ b/threedi_schema/tests/test_migration.py
@@ -216,7 +216,7 @@ class TestMigration223:
     pytestmark = pytest.mark.migration_223
     removed_tables = set(['v2_surface', 'v2_surface_parameters', 'v2_surface_map',
                           'v2_impervious_surface', 'v2_impervious_surface_map'])
-    added_tables = set(['surface', 'surface_map', 'surface_parameters', 'tags',
+    added_tables = set(['surface', 'surface_map', 'surface_parameters', 'tag',
                         'dry_weather_flow', 'dry_weather_flow_map', 'dry_weather_flow_distribution'])
 
     def test_tables(self, schema_ref, schema_upgraded):


### PR DESCRIPTION
Note that the class name is still `Tags`. This will be changed as part of https://app.zenhub.com/workspaces/team-3di-5ef60eff1973dd0024268b90/issues/gh/nens/threedi-schema/119. Preferably, I start on this once the 1D upgrade branches are merged because this requires changes accross repos.