### PR TITLE
Improve performance of migration 228

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 2019
-          - python: 3.8
-            os: ubuntu-20.04
-            pins: "sqlalchemy==1.4.44 alembic==1.8.* geoalchemy2==0.14.0"
           # 2021
           - python: 3.9
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             pins: "sqlalchemy==1.4.44 alembic==1.8.* geoalchemy2==0.14.0"
           # 2022
           - python: "3.10"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog of threedi-schema
 --------------------
 
 - Significantly speed up migration to schema 228 for schematisations with many 1D components
+- Remove support for python 3.8 and require python 3.9 as minimal version
 
 
 0.228.1 (2024-11-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog of threedi-schema
 0.228.2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Significantly speed up migration to schema 228 for schematisations with many 1D components
 
 
 0.228.1 (2024-11-26)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     {name = "Nelen & Schuurmans", email = "info@nelen-schuurmans.nl"},
 ]
 description = "The schema of 3Di schematization files"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 keywords = []
 license = {text = "MIT"}
 classifiers = [

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -188,15 +188,17 @@ def extend_cross_section_definition_table():
         WHERE v2_cross_section_definition.shape IN (5,6,7)   
         AND height IS NOT NULL AND width IS NOT NULL
     """)).fetchall()
+    update_data = []
     for id, h, w, s in res:
-        temp_row = session.query(Temp).filter_by(id=id).first()
         # tabulated_YZ: width -> Y; height -> Z
         if s == constants.CrossSectionShape.TABULATED_YZ.value:
-            temp_row.cross_section_table = make_table(w, h)
+            cross_section_table = make_table(w, h)
         # tabulated_trapezium or tabulated_rectangle: height, width
         else:
-            temp_row.cross_section_table = make_table(h, w)
-        session.commit()
+            cross_section_table = make_table(h, w)
+        update_data.append({"id": id, "cross_section_table": cross_section_table})
+    session.bulk_update_mappings(Temp, update_data)
+    session.commit()
     # add cross_section_friction_table to cross_section_definition
     res = conn.execute(sa.text("""
         SELECT id, friction_values FROM v2_cross_section_definition 
@@ -368,14 +370,12 @@ def create_connection_node():
     set_items = ',\n'.join(f"""{rename_map.get(col_name, col_name)} = (
         SELECT v2_manhole.{col_name} FROM v2_manhole
         WHERE v2_manhole.connection_node_id = connection_node.id)""" for col_name in old_col_names)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_v2_manhole_connection_node_id ON v2_manhole(connection_node_id)")
     op.execute(sa.text(f"""
         UPDATE connection_node
         SET {set_items}
-        WHERE EXISTS (
-            SELECT 1
-            FROM v2_manhole
-            WHERE v2_manhole.connection_node_id = connection_node.id
-        );
+        FROM v2_manhole
+        WHERE v2_manhole.connection_node_id = connection_node.id;
     """))
 
 


### PR DESCRIPTION
Performance changes (for schematisations mentioned in ticket):

| schematisation    | upgrade time 227->228 with 228.1 | upgrade time 227 -> 228 with this branch |
| ----------------- | -------------------------------- | ---------------------------------------- |
| zevenaar          | 4.39                             | 0.34                                     |
| bwn_wieringermeer | 6.08                             | 1.20                                     |

Because this big performance improvement to the newest, unreleased, migration, I'd like to merge this into master and release a new package.

