### PR TITLE
Fix problem spatialite upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog of threedi-schema
 0.228.3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix issue with incorrect types of migrated cross_section_width and height that broke the spatialite upgrade
 
 
 0.228.2 (2024-12-04)

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -183,7 +183,7 @@ def extend_cross_section_definition_table():
             height = None
         data_to_insert.append({"id": id, "shape": shape, "width": width, "height": height})    # insert data into the temp table
     for data in data_to_insert:
-        op.execute(sa.text(
+        conn.execute(sa.text(
             f"""INSERT INTO {Temp.__tablename__} (id, cross_section_shape, cross_section_width, cross_section_height)
             VALUES (:id, :shape, :width, :height)"""), data)  # Pass parameters as dictionary directly
     def make_table(*args):

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -486,7 +486,7 @@ def upgrade():
     modify_control_target_type()
     fix_material_id()
     fix_geometry_columns()
-    # remove_tables([old for old, _ in RENAME_TABLES]+DELETE_TABLES+[Temp.__tablename__, 'v2_manhole'])
+    remove_tables([old for old, _ in RENAME_TABLES]+DELETE_TABLES+[Temp.__tablename__, 'v2_manhole'])
 
 
 def downgrade():

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -205,7 +205,7 @@ def extend_cross_section_definition_table():
         # tabulated_trapezium or tabulated_rectangle: height, width
         else:
             cross_section_table = make_table(h, w)
-        update_data.append({"id": id,  "cross_section_table": cross_section_table})
+        update_data.append({"id": id, "cross_section_table": cross_section_table})
     session.bulk_update_mappings(Temp, update_data)
     session.commit()
     # add cross_section_friction_table to cross_section_definition


### PR DESCRIPTION
Copying all width and height from cross_section_definition to the temp table (used to populate other tables) caused problems for cases where width and height could not be converted to floats. This is now resolved by setting these values to None before migrating.