### PR TITLE
Fix sanitize comma separated fields

### DIFF
--- a/threedi_schema/domain/custom_types.py
+++ b/threedi_schema/domain/custom_types.py
@@ -102,12 +102,12 @@ class CSVTable(TypeDecorator):
 
     def process_bind_param(self, value, dialect):
         if value is not None:
-            value = clean_csv_table()
+            value = clean_csv_table(value)
         return value
 
     def process_result_value(self, value, dialect):
         if value is not None:
-            value = clean_csv_table()
+            value = clean_csv_table(value)
         return value
 
 

--- a/threedi_schema/tests/test_custom_types.py
+++ b/threedi_schema/tests/test_custom_types.py
@@ -26,6 +26,10 @@ def test_clean_csv_string(value):
     assert clean_csv_string(value) == "1,2,3"
 
 
+def test_clean_csv_string_with_whitespace():
+    assert clean_csv_string("1,2 3,4") == "1,2 3,4"
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -37,3 +41,10 @@ def test_clean_csv_string(value):
 )
 def test_clean_csv_table(value):
     assert clean_csv_table(value) == "1,2,3\n4,5,6"
+
+
+@pytest.mark.parametrize(
+    "value", [" ", "0 1", "3;5", "foo", "1,2\n3,", ",2", ",2\n3,4"]
+)
+def test_clean_csv_table_no_fail(value):
+    clean_csv_table(value)

--- a/threedi_schema/tests/test_custom_types.py
+++ b/threedi_schema/tests/test_custom_types.py
@@ -1,0 +1,39 @@
+import pytest
+
+from threedi_schema.domain.custom_types import clean_csv_string, clean_csv_table
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1,2,3",
+        "1, 2, 3 ",
+        "1,\t2,3",
+        "1,\r2,3 ",
+        "1,\n2,3 ",
+        "1,  2,3",
+        "1,  2  ,3",
+        " 1,2,3 ",
+        "\n1,2,3",
+        "\t1,2,3",
+        "\r1,2,3",
+        "1,2,3\t",
+        "1,2,3\n",
+        "1,2,3\r",
+    ],
+)
+def test_clean_csv_string(value):
+    assert clean_csv_string(value) == "1,2,3"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1,2,3\n4,5,6",
+        "1,2,3\r\n4,5,6",
+        "\n1,2,3\n4,5,6",
+        "1,2,3\n4,5,6\n",
+    ],
+)
+def test_clean_csv_table(value):
+    assert clean_csv_table(value) == "1,2,3\n4,5,6"


### PR DESCRIPTION
Previous solution was short-sighted. For example a string "1 2 3" would become "123". Conditions are thought out in more detail now.

For comma separated strings: remove white space surrounding, and remove leading and trailing white spaces, including tabs and new lines. E.g.:

```
1,2,3 -> 1,2,3
1, 2, 3 -> 1,2,3
1 2 3 -> 1 2 3
1,2, 3 -> 1,2,3
1,\t2,\t3\n -> 1,2,3
```

For tables remove any leading or trailing white space and then do the above for every line.