### PR TITLE
Remove usage of ORM from migrations 228 and 229

### DIFF
--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -91,13 +91,10 @@ ADD_COLUMNS = [
     ("culvert", Column("material_id", Integer)),
     ("orifice", Column("tags", Text)),
     ("orifice", Column("material_id", Integer)),
-    # ("orifice", Column("geom", Geometry("LINESTRING"), nullable=False)),
-    # ("pipe", Column("geom", Geometry("LINESTRING"), nullable=False)),
     ("pipe", Column("tags", Text)),
     ("pump", Column("tags", Text)),
     ("weir", Column("tags", Text)),
     ("weir", Column("material_id", Integer)),
-    # ("weir", Column("geom", Geometry("LINESTRING"), nullable=False)),
     ("windshielding_1d", Column("tags", Text)),
 ]
 

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -15,7 +15,7 @@ from alembic import op
 from sqlalchemy import Column, Float, func, Integer, select, String, Text
 from sqlalchemy.orm import declarative_base, Session
 
-from threedi_schema.domain import constants, models
+from threedi_schema.domain import constants
 from threedi_schema.domain.custom_types import Geometry, IntegerEnum
 from threedi_schema.migrations.utils import drop_conflicting, drop_geo_table
 

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -446,6 +446,15 @@ def create_connection_node():
     """))
 
 
+# define Material class needed to populate table in create_material
+class Material(Base):
+    __tablename__ = "material"
+    id = Column(Integer, primary_key=True)
+    description = Column(Text)
+    friction_type = Column(IntegerEnum(constants.FrictionType))
+    friction_coefficient = Column(Float)
+
+
 def create_material():
     op.execute(sa.text("""
     CREATE TABLE material (
@@ -457,11 +466,10 @@ def create_material():
     connection = op.get_bind()
     nof_settings = connection.execute(sa.text("SELECT COUNT(*) FROM model_settings")).scalar()
     session = Session(bind=op.get_bind())
-    # TODO fix this without using models (make temp model)
     if nof_settings > 0:
         with open(data_dir.joinpath('0228_materials.csv')) as file:
             reader = csv.DictReader(file)
-            session.bulk_save_objects([models.Material(**row) for row in reader])
+            session.bulk_save_objects([Material(**row) for row in reader])
             session.commit()
 
 

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -454,9 +454,10 @@ def create_material():
     friction_type INTEGER,
     friction_coefficient REAL);
     """))
+    connection = op.get_bind()
+    nof_settings = connection.execute(sa.text("SELECT COUNT(*) FROM model_settings")).scalar()
     session = Session(bind=op.get_bind())
-    # TODO replace
-    nof_settings = session.execute(select(func.count()).select_from(models.ModelSettings)).scalar()
+    # TODO fix this without using models (make temp model)
     if nof_settings > 0:
         with open(data_dir.joinpath('0228_materials.csv')) as file:
             reader = csv.DictReader(file)

--- a/threedi_schema/migrations/versions/0229_clean_up.py
+++ b/threedi_schema/migrations/versions/0229_clean_up.py
@@ -98,33 +98,24 @@ def clean_by_type(type: str):
 def update_use_settings():
     # Ensure that use_* settings are only True when there is actual data for them
     use_settings = [
-        (models.ModelSettings.use_groundwater_storage, models.GroundWater),
-        (models.ModelSettings.use_groundwater_flow, models.GroundWater),
-        (models.ModelSettings.use_interflow, models.Interflow),
-        (models.ModelSettings.use_simple_infiltration, models.SimpleInfiltration),
-        (models.ModelSettings.use_vegetation_drag_2d, models.VegetationDrag),
-        (models.ModelSettings.use_interception, models.Interception)
+        ('use_groundwater_storage', 'groundwater'),
+        ('use_groundwater_flow', 'groundwater'),
+        ('use_interflow', 'interflow'),
+        ('use_simple_infiltration', 'simple_infiltration'),
+        ('use_vegetation_drag_2d', 'vegetation_drag_2d'),
+        ('use_interception', 'interception')
     ]
     connection = op.get_bind()  # Get the connection for raw SQL execution
     for setting, table in use_settings:
-        use_row = connection.execute(
-            sa.select(getattr(models.ModelSettings, setting.name))
-        ).scalar()
+        use_row = connection.execute(sa.text(f"SELECT {setting} FROM model_settings")).scalar()
         if not use_row:
             continue
-        row = connection.execute(sa.select(table)).first()
+        row = connection.execute(sa.text(f"SELECT * FROM {table}")).first()
         use_row = (row is not None)
         if use_row:
-            use_row = not all(
-                getattr(row, column.name) in (None, "")
-                for column in table.__table__.columns
-                if column.name != "id"
-            )
+            use_row = not all(item in (None, "") for item in row[1:])
         if not use_row:
-            connection.execute(
-                sa.update(models.ModelSettings)
-                .values({setting.name: False})
-            )
+            connection.execute(sa.text(f"UPDATE model_settings SET {setting} = 0"))
 
             
 def upgrade():

--- a/threedi_schema/tests/test_migration.py
+++ b/threedi_schema/tests/test_migration.py
@@ -64,7 +64,11 @@ def get_columns_from_sqlite(cursor, table_name):
     for c in cursor.fetchall():
         if 'geom' in c[1]:
             continue
-        type_str = c[2].lower() if c[2] != 'bool' else 'boolean'
+        type_str = c[2].lower()
+        if type_str == 'bool':
+            type_str = 'boolean'
+        if type_str == 'int':
+            type_str = 'integer'
         col_map[c[1]] = (type_str, not c[3])
     return col_map
 


### PR DESCRIPTION
It seemed very smart at the time, but now I found out that using the ORM definitions from models is very very stupid because it will break when the model is changed in the future. So I removed any usage of `models` and replaced everything with pure sqlite or ad hoc definitions. 

I don't think/hope I need to put this in the CHANGES