### PR TITLE
Fix problem with culvert geom migration in 228

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog of threedi-schema
 
 
 
+0.229.1 (unreleased)
+--------------------
+
+- Nothing changed yet.
+
+
 0.229.0 (2025-01-08)
 --------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog of threedi-schema
 
 
 
+0.228.4 (unreleased)
+--------------------
+
+- Nothing changed yet.
+
+
 0.228.3 (2024-12-10)
 --------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,17 @@ Changelog of threedi-schema
 
 
 
-0.228.4 (unreleased)
+0.229.0 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Rename sqlite table "tags" to "tag"
+- Remove indices referring to removed tables in previous migrations
+- Make model_settings.use_2d_rain and model_settings.friction_averaging booleans
+- Remove columns referencing v2 in geometry_column
+- Ensure correct use_* values when matching tables have no data
+- Use custom types for comma separated and table text fields to strip extra white space
+- Correct direction of dwf and surface map
+- Remove v2 related views from sqlite
 
 
 0.228.3 (2024-12-10)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog of threedi-schema
 
 
 
-0.229.0 (unreleased)
+0.229.0 (2025-01-08)
 --------------------
 
 - Rename sqlite table "tags" to "tag"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog of threedi-schema
 0.229.1 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix issue where invalid geometries broke migration 228 for culverts
 
 
 0.229.0 (2025-01-08)

--- a/threedi_schema/__init__.py
+++ b/threedi_schema/__init__.py
@@ -2,6 +2,6 @@ from .application import *  # NOQA
 from .domain import constants, custom_types, models  # NOQA
 
 # fmt: off
-__version__ = '0.228.4.dev0'
+__version__ = '0.229.0.dev0'
 
 # fmt: on

--- a/threedi_schema/__init__.py
+++ b/threedi_schema/__init__.py
@@ -2,6 +2,6 @@ from .application import *  # NOQA
 from .domain import constants, custom_types, models  # NOQA
 
 # fmt: off
-__version__ = '0.228.3'
+__version__ = '0.228.4.dev0'
 
 # fmt: on

--- a/threedi_schema/__init__.py
+++ b/threedi_schema/__init__.py
@@ -2,6 +2,6 @@ from .application import *  # NOQA
 from .domain import constants, custom_types, models  # NOQA
 
 # fmt: off
-__version__ = '0.229.0.dev0'
+__version__ = '0.229.0'
 
 # fmt: on

--- a/threedi_schema/__init__.py
+++ b/threedi_schema/__init__.py
@@ -2,6 +2,6 @@ from .application import *  # NOQA
 from .domain import constants, custom_types, models  # NOQA
 
 # fmt: off
-__version__ = '0.229.0'
+__version__ = '0.229.1.dev0'
 
 # fmt: on

--- a/threedi_schema/domain/models.py
+++ b/threedi_schema/domain/models.py
@@ -1,8 +1,8 @@
-from sqlalchemy import Boolean, Column, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Column, Float, Integer, String, Text
 from sqlalchemy.orm import declarative_base
 
 from . import constants
-from .custom_types import Geometry, IntegerEnum, VarcharEnum
+from .custom_types import CSVTable, CSVText, Geometry, IntegerEnum, VarcharEnum
 
 Base = declarative_base()  # automap_base()
 
@@ -13,12 +13,12 @@ class Lateral2D(Base):
     code = Column(Text)
     display_name = Column(Text)
     type = Column(IntegerEnum(constants.Later2dType))
-    timeseries = Column(Text)
+    timeseries = Column(CSVText)
     time_units = Column(Text)
     interpolate = Column(Boolean)
     offset = Column(Integer)
     units = Column(Text)
-    tags = Column(Text)
+    tags = Column(CSVText)
     geom = Column(Geometry("POINT"), nullable=False)
 
 
@@ -28,10 +28,10 @@ class BoundaryConditions2D(Base):
     code = Column(Text)
     display_name = Column(Text)
     type = Column(IntegerEnum(constants.BoundaryType))
-    timeseries = Column(Text)
+    timeseries = Column(CSVText)
     time_units = Column(Text)
     interpolate = Column(Boolean)
-    tags = Column(Text)
+    tags = Column(CSVText)
     geom = Column(Geometry("LINESTRING"), nullable=False)
 
 
@@ -43,7 +43,7 @@ class ControlMeasureLocation(Base):
     display_name = Column(Text)
     code = Column(Text)
     geom = Column(Geometry("POINT"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class ControlMeasureMap(Base):
@@ -56,7 +56,7 @@ class ControlMeasureMap(Base):
     display_name = Column(Text)
     code = Column(Text)
     geom = Column(Geometry("LINESTRING"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class ControlMemory(Base):
@@ -74,13 +74,13 @@ class ControlMemory(Base):
     display_name = Column(Text)
     code = Column(Text)
     geom = Column(Geometry("POINT"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class ControlTable(Base):
     __tablename__ = "table_control"
     id = Column(Integer, primary_key=True)
-    action_table = Column(Text)
+    action_table = Column(CSVTable)
     action_type = Column(VarcharEnum(constants.ControlTableActionTypes))
     measure_operator = Column(VarcharEnum(constants.MeasureOperators))
     target_type = Column(VarcharEnum(constants.StructureControlTypes))
@@ -88,7 +88,7 @@ class ControlTable(Base):
     display_name = Column(Text)
     code = Column(Text)
     geom = Column(Geometry("POINT"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class Interflow(Base):
@@ -130,7 +130,7 @@ class SurfaceParameter(Base):
     min_infiltration_capacity = Column(Float, nullable=False)
     infiltration_decay_constant = Column(Float, nullable=False)
     infiltration_recovery_constant = Column(Float, nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
     description = Column(Text)
 
 
@@ -140,14 +140,12 @@ class Surface(Base):
     code = Column(String(100))
     display_name = Column(String(255))
     area = Column(Float)
-    surface_parameters_id = Column(
-        Integer, ForeignKey(SurfaceParameter.__tablename__ + ".id"), nullable=False
-    )
+    surface_parameters_id = Column(Integer)
     geom = Column(
         Geometry("POLYGON"),
         nullable=True,
     )
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class DryWeatherFlow(Base):
@@ -163,7 +161,7 @@ class DryWeatherFlow(Base):
         Geometry("POLYGON"),
         nullable=False,
     )
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class DryWeatherFlowMap(Base):
@@ -178,15 +176,15 @@ class DryWeatherFlowMap(Base):
         nullable=False,
     )
     percentage = Column(Float)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class DryWeatherFlowDistribution(Base):
     __tablename__ = "dry_weather_flow_distribution"
     id = Column(Integer, primary_key=True)
     description = Column(Text)
-    tags = Column(Text)
-    distribution = Column(Text)
+    tags = Column(CSVText)
+    distribution = Column(CSVText)
 
 
 class GroundWater(Base):
@@ -239,7 +237,7 @@ class GridRefinementLine(Base):
     grid_level = Column(Integer)
     geom = Column(Geometry("LINESTRING"), nullable=False)
     code = Column(String(100))
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class GridRefinementArea(Base):
@@ -249,7 +247,7 @@ class GridRefinementArea(Base):
     grid_level = Column(Integer)
     code = Column(String(100))
     geom = Column(Geometry("POLYGON"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class ConnectionNode(Base):
@@ -257,7 +255,7 @@ class ConnectionNode(Base):
     id = Column(Integer, primary_key=True)
     geom = Column(Geometry("POINT"), nullable=False)
     code = Column(String(100))
-    tags = Column(Text)
+    tags = Column(CSVText)
     display_name = Column(Text)
     storage_area = Column(Float)
     initial_water_level = Column(Float)
@@ -276,12 +274,12 @@ class Lateral1d(Base):
     id = Column(Integer, primary_key=True)
     code = Column(Text)
     display_name = Column(Text)
-    timeseries = Column(Text)
+    timeseries = Column(CSVText)
     time_units = Column(Text)
     interpolate = Column(Boolean)
     offset = Column(Integer)
     units = Column(Text)
-    tags = Column(Text)
+    tags = Column(CSVText)
     geom = Column(Geometry("POINT"), nullable=False)
 
     connection_node_id = Column(Integer)
@@ -354,9 +352,9 @@ class ModelSettings(Base):
     embedded_cutoff_threshold = Column(Float)
     epsg_code = Column(Integer)
     max_angle_1d_advection = Column(Float)
-    friction_averaging = Column(IntegerEnum(constants.OffOrStandard))
+    friction_averaging = Column(Boolean)
     table_step_size_1d = Column(Float)
-    use_2d_rain = Column(Integer)
+    use_2d_rain = Column(Boolean)
     use_interflow = Column(Boolean)
     use_interception = Column(Boolean)
     use_simple_infiltration = Column(Boolean)
@@ -409,7 +407,7 @@ class PhysicalSettings(Base):
     __tablename__ = "physical_settings"
     id = Column(Integer, primary_key=True)
     use_advection_1d = Column(IntegerEnum(constants.AdvectionTypes1D))
-    use_advection_2d = Column(IntegerEnum(constants.OffOrStandard))
+    use_advection_2d = Column(Boolean)
 
 
 class SimulationTemplateSettings(Base):
@@ -437,10 +435,10 @@ class BoundaryCondition1D(Base):
     code = Column(Text)
     display_name = Column(Text)
     type = Column(IntegerEnum(constants.BoundaryType))
-    timeseries = Column(Text)
+    timeseries = Column(CSVText)
     time_units = Column(Text)
     interpolate = Column(Boolean)
-    tags = Column(Text)
+    tags = Column(CSVText)
     geom = Column(Geometry("POINT"), nullable=False)
 
     connection_node_id = Column(Integer)
@@ -450,12 +448,10 @@ class SurfaceMap(Base):
     __tablename__ = "surface_map"
     id = Column(Integer, primary_key=True)
     surface_id = Column(Integer, nullable=False)
-    connection_node_id = Column(
-        Integer, ForeignKey(ConnectionNode.__tablename__ + ".id"), nullable=False
-    )
+    connection_node_id = Column(Integer)
     percentage = Column(Float)
     geom = Column(Geometry("LINESTRING"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
     code = Column(String(100))
     display_name = Column(String(255))
 
@@ -465,7 +461,7 @@ class Channel(Base):
     id = Column(Integer, primary_key=True)
     display_name = Column(String(255))
     code = Column(String(100))
-    tags = Column(Text)
+    tags = Column(CSVText)
     exchange_type = Column(IntegerEnum(constants.CalculationType))
     calculation_point_distance = Column(Float)
     geom = Column(Geometry("LINESTRING"), nullable=False)
@@ -489,14 +485,14 @@ class Windshielding(Base):
     northwest = Column(Float)
     geom = Column(Geometry("POINT"), nullable=False)
     channel_id = Column(Integer)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class CrossSectionLocation(Base):
     __tablename__ = "cross_section_location"
     id = Column(Integer, primary_key=True)
     code = Column(String(100))
-    tags = Column(Text)
+    tags = Column(CSVText)
     reference_level = Column(Float)
     friction_type = Column(IntegerEnum(constants.FrictionType))
     friction_value = Column(Float)
@@ -504,9 +500,9 @@ class CrossSectionLocation(Base):
     cross_section_shape = Column(IntegerEnum(constants.CrossSectionShape))
     cross_section_width = Column(Float)
     cross_section_height = Column(Float)
-    cross_section_friction_values = Column(Text)
-    cross_section_vegetation_table = Column(Text)
-    cross_section_table = Column(Text)
+    cross_section_friction_values = Column(CSVText)
+    cross_section_vegetation_table = Column(CSVTable)
+    cross_section_table = Column(CSVTable)
     vegetation_stem_density = Column(Float)
     vegetation_stem_diameter = Column(Float)
     vegetation_height = Column(Float)
@@ -520,7 +516,7 @@ class Pipe(Base):
     id = Column(Integer, primary_key=True)
     display_name = Column(String(255))
     code = Column(String(100))
-    tags = Column(Text)
+    tags = Column(CSVText)
     geom = Column(Geometry("LINESTRING"), nullable=False)
     sewerage_type = Column(IntegerEnum(constants.SewerageType))
     exchange_type = Column(IntegerEnum(constants.PipeCalculationType))
@@ -535,7 +531,7 @@ class Pipe(Base):
     cross_section_shape = Column(IntegerEnum(constants.CrossSectionShape))
     cross_section_width = Column(Float)
     cross_section_height = Column(Float)
-    cross_section_table = Column(Text)
+    cross_section_table = Column(CSVTable)
     exchange_thickness = Column(Float)
     hydraulic_conductivity_in = Column(Float)
     hydraulic_conductivity_out = Column(Float)
@@ -546,7 +542,7 @@ class Culvert(Base):
     id = Column(Integer, primary_key=True)
     display_name = Column(String(255))
     code = Column(String(100))
-    tags = Column(Text)
+    tags = Column(CSVText)
     exchange_type = Column(IntegerEnum(constants.CalculationTypeCulvert))
     friction_value = Column(Float)
     friction_type = Column(IntegerEnum(constants.FrictionType))
@@ -562,7 +558,7 @@ class Culvert(Base):
     cross_section_shape = Column(IntegerEnum(constants.CrossSectionShape))
     cross_section_width = Column(Float)
     cross_section_height = Column(Float)
-    cross_section_table = Column(Text)
+    cross_section_table = Column(CSVTable)
 
 
 class DemAverageArea(Base):
@@ -571,7 +567,7 @@ class DemAverageArea(Base):
     geom = Column(Geometry("POLYGON"), nullable=False)
     display_name = Column(Text)
     code = Column(Text)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class Weir(Base):
@@ -580,7 +576,7 @@ class Weir(Base):
     code = Column(String(100))
     display_name = Column(String(255))
     geom = Column(Geometry("LINESTRING"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
     crest_level = Column(Float)
     crest_type = Column(IntegerEnum(constants.CrestType))
     friction_value = Column(Float)
@@ -595,7 +591,7 @@ class Weir(Base):
     cross_section_shape = Column(IntegerEnum(constants.CrossSectionShape))
     cross_section_width = Column(Float)
     cross_section_height = Column(Float)
-    cross_section_table = Column(Text)
+    cross_section_table = Column(CSVTable)
 
 
 class Orifice(Base):
@@ -603,7 +599,7 @@ class Orifice(Base):
     id = Column(Integer, primary_key=True)
     code = Column(String(100))
     display_name = Column(String(255))
-    tags = Column(Text)
+    tags = Column(CSVText)
     geom = Column(Geometry("LINESTRING"), nullable=False)
     crest_type = Column(IntegerEnum(constants.CrestType))
     crest_level = Column(Float)
@@ -618,7 +614,7 @@ class Orifice(Base):
     cross_section_shape = Column(IntegerEnum(constants.CrossSectionShape))
     cross_section_width = Column(Float)
     cross_section_height = Column(Float)
-    cross_section_table = Column(Text)
+    cross_section_table = Column(CSVTable)
 
 
 class Pump(Base):
@@ -636,7 +632,7 @@ class Pump(Base):
     sewerage = Column(Boolean)
     connection_node_id = Column(Integer)
     geom = Column(Geometry("POINT"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class PumpMap(Base):
@@ -645,7 +641,7 @@ class PumpMap(Base):
     pump_id = Column(Integer)
     connection_node_id_end = Column(Integer)
     geom = Column(Geometry("LINESTRING"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
     code = Column(String(100))
     display_name = Column(String(255))
 
@@ -656,7 +652,7 @@ class Obstacle(Base):
     code = Column(String(100))
     crest_level = Column(Float)
     geom = Column(Geometry("LINESTRING"), nullable=False)
-    tags = Column(Text)
+    tags = Column(CSVText)
     display_name = Column(String(255))
     affects_2d = Column(Boolean)
     affects_1d2d_open_water = Column(Boolean)
@@ -668,7 +664,7 @@ class PotentialBreach(Base):
     id = Column(Integer, primary_key=True)
     code = Column(String(100))
     display_name = Column(String(255))
-    tags = Column(Text)
+    tags = Column(CSVText)
     initial_exchange_level = Column(Float)
     final_exchange_level = Column(Float)
     levee_material = Column(IntegerEnum(constants.Material))
@@ -684,11 +680,11 @@ class ExchangeLine(Base):
     exchange_level = Column(Float)
     display_name = Column(Text)
     code = Column(Text)
-    tags = Column(Text)
+    tags = Column(CSVText)
 
 
 class Tags(Base):
-    __tablename__ = "tags"
+    __tablename__ = "tag"
     id = Column(Integer, primary_key=True)
     description = Column(Text)
 

--- a/threedi_schema/migrations/utils.py
+++ b/threedi_schema/migrations/utils.py
@@ -1,0 +1,32 @@
+from typing import List
+
+import sqlalchemy as sa
+
+
+def drop_geo_table(op, table_name: str):
+    """
+
+    Safely drop table, taking into account geometry columns
+
+    Parameters:
+    op : object
+        An object representing the database operation.
+    table_name : str
+        The name of the table to be dropped.
+    """
+    op.execute(sa.text(f"SELECT DropTable(NULL, '{table_name}');"))
+
+
+def drop_conflicting(op, new_tables: List[str]):
+    """
+    Drop tables from database that conflict with new tables
+
+    Parameters:
+    op: The SQLAlchemy operation context to interact with the database.
+    new_tables: A list of new table names to be checked for conflicts with existing tables.
+    """
+    connection = op.get_bind()
+    existing_tables = [item[0] for item in connection.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table';")).fetchall()]
+    for table_name in set(existing_tables).intersection(new_tables):
+        drop_geo_table(op, table_name)

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -15,6 +15,7 @@ from sqlalchemy import Boolean, Column, Float, Integer, String, Text
 from sqlalchemy.orm import declarative_base
 
 from threedi_schema.domain.custom_types import Geometry
+from threedi_schema.migrations.utils import drop_conflicting, drop_geo_table
 
 # revision identifiers, used by Alembic.
 revision = "0224"
@@ -335,7 +336,7 @@ def remove_column_from_table(table_name: str, column: str):
 
 def remove_tables(tables: List[str]):
     for table in tables:
-        op.drop_table(table)
+        drop_geo_table(op, table)
 
 
 def make_geom_col_notnull(table_name):
@@ -357,7 +358,7 @@ def make_geom_col_notnull(table_name):
     temp_name = f'_temp_224_{uuid.uuid4().hex}'
     op.execute(sa.text(f"CREATE TABLE {temp_name} ({','.join(cols)});"))
     op.execute(sa.text(f"INSERT INTO {temp_name} ({','.join(col_names)}) SELECT {','.join(col_names)} FROM {table_name}"))
-    op.execute(sa.text(f"DROP TABLE {table_name};"))
+    drop_geo_table(op, table_name)
     op.execute(sa.text(f"ALTER TABLE {temp_name} RENAME TO {table_name};"))
 
 
@@ -370,15 +371,20 @@ def fix_geometry_columns():
         op.execute(sa.text(migration_query))
 
 
-def drop_conflicting():
-    new_tables = list(ADD_TABLES.keys()) + [new_name for _, new_name in RENAME_TABLES]
-    for table_name in new_tables:
-        op.execute(f"DROP TABLE IF EXISTS {table_name};")
+def update_use_structure_control():
+    op.execute("""
+        UPDATE simulation_template_settings SET use_structure_control = CASE
+            WHEN
+                (SELECT COUNT(*) FROM table_control) = 0 AND
+                (SELECT COUNT(*) FROM memory_control) = 0 THEN 0
+            ELSE use_structure_control
+            END;    
+    """)
 
 
 def upgrade():
     # Remove existing tables (outside of the specs) that conflict with new table names
-    drop_conflicting()
+    drop_conflicting(op, list(ADD_TABLES.keys()) + [new_name for _, new_name in RENAME_TABLES])
     # create new tables and rename existing tables
     create_new_tables(ADD_TABLES)
     rename_tables(RENAME_TABLES)
@@ -400,6 +406,7 @@ def upgrade():
     rename_measure_operator('memory_control')
     move_setting('model_settings', 'use_structure_control',
                  'simulation_template_settings', 'use_structure_control')
+    update_use_structure_control()
     remove_tables(DEL_TABLES)
     # Fix geometry columns and also make all but geom column nullable
     fix_geometry_columns()

--- a/threedi_schema/migrations/versions/0226_upgrade_db_1d_1d2d.py
+++ b/threedi_schema/migrations/versions/0226_upgrade_db_1d_1d2d.py
@@ -12,7 +12,7 @@ from alembic import op
 from sqlalchemy import Boolean, Column, Float, Integer, String, Text
 from sqlalchemy.orm import declarative_base
 
-from threedi_schema.domain.custom_types import Geometry
+from threedi_schema.migrations.utils import drop_conflicting, drop_geo_table
 
 # revision identifiers, used by Alembic.
 revision = "0226"
@@ -74,7 +74,7 @@ def add_columns_to_tables(table_columns: List[Tuple[str, Column]]):
 
 def remove_tables(tables: List[str]):
     for table in tables:
-        op.drop_table(table)
+        drop_geo_table(op, table)
 
 
 def modify_table(old_table_name, new_table_name):
@@ -167,15 +167,9 @@ def set_potential_breach_final_exchange_level():
     ))
 
 
-def drop_conflicting():
-    new_tables = [new_name for _, new_name in RENAME_TABLES]
-    for table_name in new_tables:
-        op.execute(f"DROP TABLE IF EXISTS {table_name};")
-
-
 def upgrade():
     # Drop tables that conflict with new table names
-    drop_conflicting()
+    drop_conflicting(op, [new_name for _, new_name in RENAME_TABLES])
     rem_tables = []
     for old_table_name, new_table_name in RENAME_TABLES:
         modify_table(old_table_name, new_table_name)

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -351,6 +351,26 @@ def set_geom_for_object(table_name: str, col_name: str = 'the_geom'):
     op.execute(sa.text(q))
 
 
+def fix_geom_for_culvert():
+    new_table_name = f'_temp_228_fix_culvert_{uuid.uuid4().hex}'
+    old_table_name = 'v2_culvert'
+    connection = op.get_bind()
+    columns = connection.execute(sa.text(f"PRAGMA table_info('{old_table_name}')")).fetchall()
+    # get all column names and types
+    col_names = [col[1] for col in columns if col[1] not in ['id', 'the_geom']]
+    col_types = [col[2] for col in columns if col[1] in col_names]
+    # Create new table (temp), insert data, drop original and rename temp to table_name
+    new_col_str = ','.join(['id INTEGER PRIMARY KEY NOT NULL'] + [f'{cname} {ctype}' for cname, ctype in
+                                                                  zip(col_names, col_types)])
+    op.execute(sa.text(f"CREATE TABLE {new_table_name} ({new_col_str});"))
+    op.execute(sa.text(f"SELECT AddGeometryColumn('{new_table_name}', 'the_geom', 4326, 'LINESTRING', 'XY', 0);"))
+    # Copy data
+    op.execute(sa.text(f"INSERT INTO {new_table_name} (id, {','.join(col_names)}, the_geom) "
+                       f"SELECT id, {','.join(col_names)}, the_geom FROM {old_table_name}"))
+    op.execute(sa.text("DROP TABLE v2_culvert"))
+    op.execute(sa.text(f"ALTER TABLE {new_table_name} RENAME TO v2_culvert"))
+
+
 def set_geom_for_v2_pumpstation():
     op.execute(sa.text(f"SELECT AddGeometryColumn('v2_pumpstation', 'the_geom', 4326, 'POINT', 'XY', 0);"))
     q = f"""
@@ -529,6 +549,8 @@ def upgrade():
         # Set geometry for tables without one
         if table_name != 'v2_culvert':
             set_geom_for_object(table_name)
+        else:
+            fix_geom_for_culvert()
     set_geom_for_v2_pumpstation()
     for old_table_name, new_table_name in RENAME_TABLES:
         modify_table(old_table_name, new_table_name)

--- a/threedi_schema/migrations/versions/0229_clean_up.py
+++ b/threedi_schema/migrations/versions/0229_clean_up.py
@@ -1,0 +1,120 @@
+"""
+
+Revision ID: 022
+9Revises:
+Create Date: 2024-11-15 14:18
+
+"""
+import uuid
+from typing import List
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0229"
+down_revision = "0228"
+branch_labels = None
+depends_on = None
+
+
+def get_geom_type(table_name, geo_col_name):
+    connection = op.get_bind()
+    columns = connection.execute(sa.text(f"PRAGMA table_info('{table_name}')")).fetchall()
+    for col in columns:
+        if col[1] == geo_col_name:
+            return col[2]
+
+def change_types_in_settings_table():
+    temp_table_name = f'_temp_229_{uuid.uuid4().hex}'
+    table_name = 'model_settings'
+    change_types = {'use_d2_rain': 'bool', 'friction_averaging': 'bool'}
+    connection = op.get_bind()
+    columns = connection.execute(sa.text(f"PRAGMA table_info('{table_name}')")).fetchall()
+    # get all column names and types
+    skip_cols = ['id', 'the_geom']
+    col_names = [col[1] for col in columns if col[1] not in skip_cols]
+    old_col_types = [col[2] for col in columns if col[1] not in skip_cols]
+    col_types = [change_types.get(col_name, col_type) for col_name, col_type in zip(col_names, old_col_types)]
+    # Create new table, insert data, drop original and rename temp to table_name
+    col_str = ','.join(['id INTEGER PRIMARY KEY NOT NULL'] + [f'{cname} {ctype}' for cname, ctype in
+                                                                  zip(col_names, col_types)])
+    op.execute(sa.text(f"CREATE TABLE {temp_table_name} ({col_str});"))
+    # Copy data
+    op.execute(sa.text(f"INSERT INTO {temp_table_name} (id, {','.join(col_names)}) "
+                       f"SELECT id, {','.join(col_names)} FROM {table_name}"))
+    op.execute(sa.text(f"DROP TABLE {table_name}"))
+    op.execute(sa.text(f"ALTER TABLE {temp_table_name} RENAME TO {table_name};"))
+
+
+def remove_tables(tables: List[str]):
+    for table in tables:
+        op.drop_table(table)
+
+
+def find_tables_by_pattern(pattern: str) -> List[str]:
+    connection = op.get_bind()
+    query = connection.execute(
+        sa.text(f"select name from sqlite_master where type = 'table' and name like '{pattern}'"))
+    return [item[0] for item in query.fetchall()]
+
+
+def remove_old_tables():
+    remaining_v2_idx_tables = find_tables_by_pattern('idx_v2_%_the_geom')
+    remaining_alembic = find_tables_by_pattern('%_alembic_%_the_geom')
+    remove_tables(remaining_v2_idx_tables + remaining_alembic)
+
+
+def clean_geometry_columns():
+    """ Remove columns referencing v2 in geometry_columns """
+    op.execute(sa.text("""
+            DELETE FROM geometry_columns WHERE f_table_name IN (
+                SELECT g.f_table_name FROM geometry_columns g
+                LEFT JOIN sqlite_master m ON g.f_table_name = m.name
+                WHERE m.name IS NULL AND g.f_table_name like "%v2%"
+            );
+        """))
+
+
+def clean_by_type(type: str):
+    connection = op.get_bind()
+    items = [item[0] for item in connection.execute(
+        sa.text(f"SELECT tbl_name FROM sqlite_master WHERE type='{type}' AND tbl_name LIKE '%v2%';")).fetchall()]
+    for item in items:
+        op.execute(f"DROP {type} IF EXISTS {item};")
+
+
+def update_use_settings():
+    # Ensure that use_* settings are only True when there is actual data for them
+    use_settings = [
+        ('use_groundwater_storage', 'groundwater'),
+        ('use_groundwater_flow', 'groundwater'),
+        ('use_interflow', 'interflow'),
+        ('use_simple_infiltration', 'simple_infiltration'),
+        ('use_vegetation_drag_2d', 'vegetation_drag_2d'),
+        ('use_interception', 'interception')
+    ]
+    connection = op.get_bind()  # Get the connection for raw SQL execution
+    for setting, table in use_settings:
+        use_row = connection.execute(sa.text(f"SELECT {setting} FROM model_settings")).scalar()
+        if not use_row:
+            continue
+        row = connection.execute(sa.text(f"SELECT * FROM {table}")).first()
+        use_row = (row is not None)
+        if use_row:
+            use_row = not all(item in (None, "") for item in row[1:])
+        if not use_row:
+            connection.execute(sa.text(f"UPDATE model_settings SET {setting} = 0"))
+
+            
+def upgrade():
+    remove_old_tables()
+    clean_geometry_columns()
+    clean_by_type('trigger')
+    clean_by_type('view')
+    update_use_settings()
+    change_types_in_settings_table()
+
+
+def downgrade():
+    pass

--- a/threedi_schema/tests/test_custom_types.py
+++ b/threedi_schema/tests/test_custom_types.py
@@ -1,0 +1,50 @@
+import pytest
+
+from threedi_schema.domain.custom_types import clean_csv_string, clean_csv_table
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1,2,3",
+        "1, 2, 3 ",
+        "1,\t2,3",
+        "1,\r2,3 ",
+        "1,\n2,3 ",
+        "1,  2,3",
+        "1,  2  ,3",
+        " 1,2,3 ",
+        "\n1,2,3",
+        "\t1,2,3",
+        "\r1,2,3",
+        "1,2,3\t",
+        "1,2,3\n",
+        "1,2,3\r",
+    ],
+)
+def test_clean_csv_string(value):
+    assert clean_csv_string(value) == "1,2,3"
+
+
+def test_clean_csv_string_with_whitespace():
+    assert clean_csv_string("1,2 3,4") == "1,2 3,4"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1,2,3\n4,5,6",
+        "1,2,3\r\n4,5,6",
+        "\n1,2,3\n4,5,6",
+        "1,2,3\n4,5,6\n",
+    ],
+)
+def test_clean_csv_table(value):
+    assert clean_csv_table(value) == "1,2,3\n4,5,6"
+
+
+@pytest.mark.parametrize(
+    "value", [" ", "0 1", "3;5", "foo", "1,2\n3,", ",2", ",2\n3,4"]
+)
+def test_clean_csv_table_no_fail(value):
+    clean_csv_table(value)

--- a/threedi_schema/tests/test_migration.py
+++ b/threedi_schema/tests/test_migration.py
@@ -64,7 +64,11 @@ def get_columns_from_sqlite(cursor, table_name):
     for c in cursor.fetchall():
         if 'geom' in c[1]:
             continue
-        type_str = c[2].lower() if c[2] != 'bool' else 'boolean'
+        type_str = c[2].lower()
+        if type_str == 'bool':
+            type_str = 'boolean'
+        if type_str == 'int':
+            type_str = 'integer'
         col_map[c[1]] = (type_str, not c[3])
     return col_map
 
@@ -216,7 +220,7 @@ class TestMigration223:
     pytestmark = pytest.mark.migration_223
     removed_tables = set(['v2_surface', 'v2_surface_parameters', 'v2_surface_map',
                           'v2_impervious_surface', 'v2_impervious_surface_map'])
-    added_tables = set(['surface', 'surface_map', 'surface_parameters', 'tags',
+    added_tables = set(['surface', 'surface_map', 'surface_parameters', 'tag',
                         'dry_weather_flow', 'dry_weather_flow_map', 'dry_weather_flow_distribution'])
 
     def test_tables(self, schema_ref, schema_upgraded):

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -219,7 +219,7 @@ def test_set_spatial_indexes(in_memory_sqlite):
             connection.execute(
                 text("SELECT DisableSpatialIndex('connection_node', 'geom')")
             ).scalar()
-            connection.execute(text("DROP TABLE idx_v2_connection_nodes_the_geom"))
+            connection.execute(text("DROP TABLE idx_connection_node_geom"))
 
     schema.set_spatial_indexes()
 


### PR DESCRIPTION
I'm not 100% sure if this is a real issue, but I ran into it while testing with some of the standard schematisations I used before. Turned out that `v2_culvert.the_geom` is not always a proper linestring in all sample schematisations. This change should fix that.