### PR TITLE
fix 1d object geometries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@ Changelog of threedi-schema
 ===================================================
 
 
+0.228.3 (unreleased)
+--------------------
+
+- Fix incorrectly setting of geometry for pipe, weir and orifice in migration
+
 
 0.228.3 (2024-12-10)
 --------------------


### PR DESCRIPTION
In the original implementation all geometries for weirs, pipes and orifices were identical. This wasn't picked up before because at the moment these geometries are only used for visualisation.