### PR TITLE
Fix buffer geometry used for surface and DWF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.229.1 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix incorrect creation of geometry for dry weather flow and surface during migration
 
 
 0.229.0 (2025-01-08)

--- a/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
+++ b/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
@@ -302,12 +302,13 @@ def copy_polygons(src_table: str, tmp_geom: str):
 
 def create_buffer_polygons(src_table: str, tmp_geom: str):
     # create circular polygon of area 1 around the connection node
+    srid = get_global_srid()
     surf_id = f"{src_table.strip('v2_')}_id"
     query = f"""
         WITH connection_data AS (
             SELECT
                 {src_table}_map.{surf_id} AS item_id,
-                ST_Buffer(v2_connection_nodes.the_geom, 1) AS buffer_geom
+                ST_Transform(ST_Buffer(ST_Transform(v2_connection_nodes.the_geom, {28992}), 1), {srid}) AS buffer_geom
             FROM
                 v2_connection_nodes
             JOIN

--- a/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
+++ b/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
@@ -308,7 +308,7 @@ def create_buffer_polygons(src_table: str, tmp_geom: str):
         WITH connection_data AS (
             SELECT
                 {src_table}_map.{surf_id} AS item_id,
-                ST_Transform(ST_Buffer(ST_Transform(v2_connection_nodes.the_geom, {28992}), 1), {srid}) AS buffer_geom
+                ST_Transform(ST_Buffer(ST_Transform(v2_connection_nodes.the_geom, {srid}), 1), 4326) AS buffer_geom
             FROM
                 v2_connection_nodes
             JOIN


### PR DESCRIPTION
When a new surface or dwf row has no geometry a buffer with radius of 1 meter around the connection node should be created. However, `ST_buffer` uses the connection node geometry units