### PR TITLE
Convert spatialite to geopackage on any migration to 300 or above

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@ Changelog of threedi-schema
 ===================================================
 
 
-0.230.1 (unreleased)
+0.300 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Convert spatialite to geopackage during upgrade
 
 
 0.230.0 (2025-01-16)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -162,9 +162,6 @@ class ModelSchema:
         Specify 'upgrade_spatialite_version=True' to also upgrade the
         spatialite file version after the upgrade.
 
-        Specify 'convert_to_geopackage=True' to also convert from spatialite
-        to geopackage file version after the upgrade.
-
         Specify a 'progress_func' to handle progress updates. `progress_func` should
         expect a single argument representing the fraction of progress
 
@@ -235,12 +232,11 @@ class ModelSchema:
                 self._remove_custom_epsg_code()
         # First upgrade to LAST_SPTL_SCHEMA_VERSION.
         # When the requested revision <= LAST_SPTL_SCHEMA_VERSION, this is the only upgrade step
-        rev_temp = (
+        run_upgrade(
             revision
             if rev_nr <= constants.LAST_SPTL_SCHEMA_VERSION
             else f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}"
         )
-        run_upgrade(rev_temp)
         # only upgrade spatialite version is target revision is <= LAST_SPTL_SCHEMA_VERSION
         if rev_nr <= constants.LAST_SPTL_SCHEMA_VERSION and upgrade_spatialite_version:
             self.upgrade_spatialite_version()

--- a/threedi_schema/domain/constants.py
+++ b/threedi_schema/domain/constants.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 LATEST_SOUTH_MIGRATION_ID = 160
+LAST_SPTL_SCHEMA_VERSION = 230
 VERSION_TABLE_NAME = "schema_version"
 
 

--- a/threedi_schema/migrations/versions/0300_geopackage.py
+++ b/threedi_schema/migrations/versions/0300_geopackage.py
@@ -1,0 +1,30 @@
+"""Reproject geometries to model CRS
+
+Revision ID: 0230
+Revises:
+Create Date: 2024-11-12 12:30
+
+"""
+import sqlite3
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+
+from threedi_schema.migrations.exceptions import InvalidSRIDException
+
+# revision identifiers, used by Alembic.
+revision = "0300"
+down_revision = "0230"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # this upgrade only changes the model version
+    pass
+
+
+def downgrade():
+    # Not implemented on purpose
+    pass

--- a/threedi_schema/scripts.py
+++ b/threedi_schema/scripts.py
@@ -42,7 +42,6 @@ def migrate(
         revision=revision,
         backup=backup,
         upgrade_spatialite_version=upgrade_spatialite_version,
-        convert_to_geopackage=convert_to_geopackage,
     )
     click.echo("The migrated schema revision is: %s" % schema.get_version())
 

--- a/threedi_schema/tests/conftest.py
+++ b/threedi_schema/tests/conftest.py
@@ -58,6 +58,5 @@ def in_memory_sqlite():
 @pytest.fixture
 def sqlite_latest(empty_sqlite_v4):
     """An in-memory database with the latest schema version"""
-    # db = ThreediDatabase("")
     empty_sqlite_v4.schema.upgrade("head", backup=False, custom_epsg_code=28992)
     return empty_sqlite_v4

--- a/threedi_schema/tests/conftest.py
+++ b/threedi_schema/tests/conftest.py
@@ -56,8 +56,8 @@ def in_memory_sqlite():
 
 
 @pytest.fixture
-def sqlite_latest(in_memory_sqlite):
+def sqlite_latest(empty_sqlite_v4):
     """An in-memory database with the latest schema version"""
-    db = ThreediDatabase("")
-    in_memory_sqlite.schema.upgrade("head", backup=False, custom_epsg_code=28992)
-    return db
+    # db = ThreediDatabase("")
+    empty_sqlite_v4.schema.upgrade("head", backup=False, custom_epsg_code=28992)
+    return empty_sqlite_v4

--- a/threedi_schema/tests/test_gpkg.py
+++ b/threedi_schema/tests/test_gpkg.py
@@ -1,14 +1,18 @@
 import pytest
 
+from threedi_schema.domain import constants
+
 
 @pytest.mark.parametrize("upgrade_spatialite", [True, False])
 def test_convert_to_geopackage(oldest_sqlite, upgrade_spatialite):
-    if upgrade_spatialite:
-        oldest_sqlite.schema.upgrade(upgrade_spatialite_version=True)
+    # if upgrade_spatialite:
+    oldest_sqlite.schema.upgrade(
+        upgrade_spatialite_version=upgrade_spatialite,
+        revision=f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
+    )
 
     oldest_sqlite.schema.convert_to_geopackage()
     # Ensure that after the conversion the geopackage is used
     assert oldest_sqlite.path.suffix == ".gpkg"
     assert not oldest_sqlite.schema.is_spatialite
     assert oldest_sqlite.schema.is_geopackage
-    assert oldest_sqlite.schema.validate_schema()

--- a/threedi_schema/tests/test_gpkg.py
+++ b/threedi_schema/tests/test_gpkg.py
@@ -1,5 +1,4 @@
 import pytest
-from sqlalchemy import text
 
 
 @pytest.mark.parametrize("upgrade_spatialite", [True, False])
@@ -10,22 +9,6 @@ def test_convert_to_geopackage(oldest_sqlite, upgrade_spatialite):
     oldest_sqlite.schema.convert_to_geopackage()
     # Ensure that after the conversion the geopackage is used
     assert oldest_sqlite.path.suffix == ".gpkg"
-    with oldest_sqlite.session_scope() as session:
-        gpkg_table_exists = bool(
-            session.execute(
-                text(
-                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='gpkg_contents';"
-                )
-            ).scalar()
-        )
-        spatialite_table_exists = bool(
-            session.execute(
-                text(
-                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='spatial_ref_sys';"
-                )
-            ).scalar()
-        )
-
-    assert gpkg_table_exists
-    assert not spatialite_table_exists
+    assert not oldest_sqlite.schema.is_spatialite
+    assert oldest_sqlite.schema.is_geopackage
     assert oldest_sqlite.schema.validate_schema()

--- a/threedi_schema/tests/test_migration_230_crs_reprojection.py
+++ b/threedi_schema/tests/test_migration_230_crs_reprojection.py
@@ -21,7 +21,7 @@ def test_check_valid_crs(in_memory_sqlite, epsg_code):
 
 def test_migration(tmp_path_factory, oldest_sqlite):
     schema = ModelSchema(oldest_sqlite)
-    schema.upgrade(backup=False)
+    schema.upgrade(backup=False, revision="0230")
     cursor = sqlite3.connect(schema.db.path).cursor()
     query = cursor.execute("SELECT srid FROM geometry_columns where f_table_name = 'geom'")
     epsg_matches = [int(item[0])==28992 for item in query.fetchall()]

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -165,12 +165,7 @@ def run_upgrade_test(schema):
         schema_cols = get_columns_from_schema(schema, table)
         sqlite_cols = get_columns_from_sqlite(session, table)
         assert set(schema_cols).issubset(set(sqlite_cols))
-    assert get_missing_spatial_indexes(schema.db, DECLARED_MODELS) == []
-
-    # check_result = session.execute(
-    #     text("SELECT CheckSpatialIndex('connection_node', 'geom')")
-    # ).scalar()
-    # assert check_result == 1
+    assert get_missing_spatial_indexes(schema.db.engine, DECLARED_MODELS) == []
 
 
 def test_upgrade_with_custom_epsg_code(in_memory_sqlite):

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -362,7 +362,10 @@ class TestGetEPSGData:
 def test_is_spatialite(in_memory_sqlite):
     schema = ModelSchema(in_memory_sqlite)
     schema.upgrade(
-        backup=False, upgrade_spatialite_version=False, custom_epsg_code=28992
+        backup=False,
+        upgrade_spatialite_version=False,
+        custom_epsg_code=28992,
+        revision=f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
     )
     assert schema.is_spatialite
 
@@ -370,7 +373,10 @@ def test_is_spatialite(in_memory_sqlite):
 def test_is_geopackage(oldest_sqlite):
     schema = ModelSchema(oldest_sqlite)
     schema.upgrade(
-        backup=False, upgrade_spatialite_version=False, custom_epsg_code=28992
+        backup=False,
+        upgrade_spatialite_version=False,
+        custom_epsg_code=28992,
+        revision=f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
     )
     schema.convert_to_geopackage()
     assert schema.is_geopackage

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -307,7 +307,11 @@ def test_upgrade_spatialite_3(oldest_sqlite):
         pytest.skip("Nothing to test: spatialite library version equals file version")
 
     schema = ModelSchema(oldest_sqlite)
-    schema.upgrade(backup=False, upgrade_spatialite_version=True)
+    schema.upgrade(
+        backup=False,
+        upgrade_spatialite_version=True,
+        revision=f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
+    )
 
     _, file_version_after = get_spatialite_version(oldest_sqlite)
     assert file_version_after == 4

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -189,9 +189,9 @@ def test_upgrade_with_custom_epsg_code(in_memory_sqlite):
         assert all([srid == 28992 for srid in srids])
 
 
-def test_upgrade_with_custom_epsg_code_version_too_new(in_memory_sqlite):
+def test_upgrade_with_custom_epsg_code_version_too_new(empty_sqlite_v4):
     """Set custom epsg code for schema version > 229"""
-    schema = ModelSchema(in_memory_sqlite)
+    schema = ModelSchema(empty_sqlite_v4)
     schema.upgrade(
         revision="0230",
         backup=False,
@@ -324,6 +324,8 @@ def test_upgrade_spatialite_3(oldest_sqlite):
     assert check_result == 1
 
 
+# TODO: remove this because ensure_spatial_indexes is already tested
+@pytest.mark.skip(reason="will be removed")
 def test_set_spatial_indexes(in_memory_sqlite):
     engine = in_memory_sqlite.engine
 
@@ -348,8 +350,8 @@ def test_set_spatial_indexes(in_memory_sqlite):
 
 
 class TestGetEPSGData:
-    def test_no_epsg(self, in_memory_sqlite):
-        schema = ModelSchema(in_memory_sqlite)
+    def test_no_epsg(self, empty_sqlite_v4):
+        schema = ModelSchema(empty_sqlite_v4)
         schema.upgrade(
             backup=False, upgrade_spatialite_version=False, custom_epsg_code=28992
         )

--- a/threedi_schema/tests/test_spatial_index.py
+++ b/threedi_schema/tests/test_spatial_index.py
@@ -1,0 +1,58 @@
+import pytest
+from geoalchemy2 import Geometry
+from sqlalchemy import Column, create_engine, func, Integer
+from sqlalchemy.event import listen
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from threedi_schema.application.threedi_database import load_spatialite
+from threedi_schema.infrastructure.spatial_index import (
+    create_spatial_index,
+    ensure_spatial_indexes,
+    get_missing_spatial_indexes,
+)
+
+Base = declarative_base()
+
+
+class Model(Base):
+    __tablename__ = "model"
+
+    id = Column(Integer, primary_key=True)
+    geom = Column(Geometry("POINT"))
+
+
+@pytest.fixture()
+def engine():
+    engine = create_engine("sqlite:///:memory:")
+    listen(engine, "connect", load_spatialite)
+
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    session.execute(func.gpkgCreateBaseTables())
+    return engine
+
+
+def test_get_missing_spatial_indexes(engine):
+    assert get_missing_spatial_indexes(engine, [Model]) == [Model]
+
+
+def test_create_spatial_index(engine):
+    with engine.connect() as connection:
+        with connection.begin():
+            create_spatial_index(connection, Model.__table__.columns["geom"])
+    assert get_missing_spatial_indexes(engine, [Model]) == []
+
+
+def test_create_spatial_index_fail(engine):
+    with engine.connect() as connection:
+        with connection.begin():
+            create_spatial_index(connection, Model.__table__.columns["geom"])
+            with pytest.raises(RuntimeError):
+                create_spatial_index(connection, Model.__table__.columns["geom"])
+
+
+def test_ensure_spatial_index(engine):
+    assert get_missing_spatial_indexes(engine, [Model]) == [Model]
+    ensure_spatial_indexes(engine, [Model])
+    assert get_missing_spatial_indexes(engine, [Model]) == []

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -48,9 +48,9 @@ def test_upgrade_with_progress_func(oldest_sqlite):
     schema = oldest_sqlite.schema
     progress_func = MagicMock()
     schema.upgrade(
+        revision="0201",
         backup=False,
         upgrade_spatialite_version=False,
         progress_func=progress_func,
-        revision="0201",
     )
     assert progress_func.call_args_list == [call(0.0), call(50.0)]


### PR DESCRIPTION
This implements the following logic on upgrade:
1. check version
    * (unchanged) Raise MigrationMissingError if schematisation version is too old 
    * (new) Raise UpgradeFailedError if schematisation is not a spatialite but has a version of 230 or older 
    * (new) Raise UpgradeFailedError if schematisation is not a geopackage but has a version of 300 or newer
2. (unchanged) set custom epsg code, this will result in a schematisation version 230
3. (new) upgrade to revision if revision <= 230, otherwise upgrade to 230
4. (new) upgrade spatialite version if requested
5. (new) if revision > 230, convert to geopackage and finish upgrade

New and changed fuctionality (with added tests):
* Added `is_geopackage` and `is_spatialite` properties to `ModelSchema` 
* Modified `spatial_index` module to work with geopackage

Note that the test schema for several tests have been changed from `in_memory_sqlite` to `empty_sqlite_v4` because geopackage conversion only works with a file.