### PR TITLE
Set default visualisation to -1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Set default visualisation of connection_node to -1
 
 
 0.300.1 (2025-01-24)

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -436,7 +436,19 @@ def create_connection_node():
     query = """
             CREATE TABLE connection_node (
             id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, 
-            code VARCHAR(100),tags TEXT,display_name TEXT,storage_area FLOAT,initial_water_level FLOAT,visualisation INTEGER,manhole_surface_level FLOAT,bottom_level FLOAT,exchange_level FLOAT,exchange_type INTEGER,exchange_thickness FLOAT,hydraulic_conductivity_in FLOAT,hydraulic_conductivity_out FLOAT,
+            code VARCHAR(100),
+            tags TEXT,
+            display_name TEXT,
+            storage_area FLOAT,
+            initial_water_level FLOAT,
+            visualisation INTEGER DEFAULT -1,
+            manhole_surface_level FLOAT,
+            bottom_level FLOAT,
+            exchange_level FLOAT,
+            exchange_type INTEGER,
+            exchange_thickness FLOAT,
+            hydraulic_conductivity_in FLOAT,
+            hydraulic_conductivity_out FLOAT,
             geom POINT NOT NULL
         );    
     """


### PR DESCRIPTION
Visualisation for connection nodes that were **not** migrated from v2_manholes should get `visualisation=-1` instead of `visulaisation=Null`. Since all these rows get the default value of `visualisation`, setting a default of -1 fixes this isse.