### PR TITLE
Fix upgrade starting from gpkg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.4 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix migration starting from geopackage
 
 
 0.300.3 (2025-01-28)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -175,6 +175,7 @@ class ModelSchema:
                 f"Incorrect version format: {revision}. Expected 'head' or a numeric value."
             )
         v = self.get_version()
+
         if v is not None and v < constants.LATEST_SOUTH_MIGRATION_ID:
             raise MigrationMissingError(
                 f"This tool cannot update versions below "
@@ -365,12 +366,12 @@ class ModelSchema:
 
         warnings_list = []
 
-        if self.db.get_engine().dialect.name == "geopackage":
+        if self.is_geopackage:
             return
 
         # Ensure database is upgraded and views are recreated
         revision = self.get_version()
-        if revision is None or revision <= constants.LAST_SPTL_SCHEMA_VERSION:
+        if revision is None or revision < constants.LAST_SPTL_SCHEMA_VERSION:
             self.upgrade(
                 revision=f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}", backup=False
             )


### PR DESCRIPTION
Running `schema.convert_to_geopackage` on a schematisation that is already a gpkg breaks because the detection for gpkg was broken