### PR TITLE
correctly overwrite model_settings epsg_code when requested

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.11 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix EPSG code setting on empty databases
 
 
 0.300.10 (2025-02-18)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -278,11 +278,15 @@ class ModelSchema:
             raise ValueError(f"Cannot set epsg code for revision {self.get_version()}")
         # modify epsg_code
         with self.db.get_session() as session:
-            settings_row_count = session.execute(text("SELECT COUNT(id) FROM model_settings;")).scalar()
+            settings_row_count = session.execute(
+                text("SELECT COUNT(id) FROM model_settings;")
+            ).scalar()
             # to update empty databases, they must have model_settings.epsg_code set
             if settings_row_count == 0:
                 session.execute(
-                    text(f"INSERT INTO model_settings (id, epsg_code) VALUES (1, {custom_epsg_code});")
+                    text(
+                        f"INSERT INTO model_settings (id, epsg_code) VALUES (1, {custom_epsg_code});"
+                    )
                 )
             else:
                 session.execute(

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -279,9 +279,7 @@ class ModelSchema:
         # modify epsg_code
         with self.db.get_session() as session:
             session.execute(
-                text(
-                    f"UPDATE model_settings SET epsg_code = {custom_epsg_code};"
-                )
+                text(f"UPDATE model_settings SET epsg_code = {custom_epsg_code};")
             )
             session.commit()
 

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -247,14 +247,13 @@ class ModelSchema:
                 )
             elif rev_nr < 230:
                 warnings.warn(
-                    "Warning: cannot set epsg_code_override when not upgrading to 229 or older."
+                    "Warning: cannot set epsg_code_override when upgrading to 229 or older."
                 )
             else:
                 if self.get_version() is None or self.get_version() < 229:
                     run_upgrade("0229")
                 self._set_custom_epsg_code(epsg_code_override)
                 run_upgrade("0230")
-                self._remove_custom_epsg_code()
         # First upgrade to LAST_SPTL_SCHEMA_VERSION.
         # When the requested revision <= LAST_SPTL_SCHEMA_VERSION, this is the only upgrade step
         run_upgrade(
@@ -281,20 +280,11 @@ class ModelSchema:
         with self.db.get_session() as session:
             session.execute(
                 text(
-                    f"INSERT INTO model_settings (id, epsg_code) VALUES (999999, {custom_epsg_code});"
+                    f"UPDATE model_settings SET epsg_code = {custom_epsg_code};"
                 )
             )
             session.commit()
 
-    def _remove_custom_epsg_code(self):
-        if self.get_version() != 230:
-            raise ValueError(
-                f"Removing the custom epsg code should only be done on revision = 230, not {self.get_version()}"
-            )
-        # Remove row added by upgrade with custom_epsg_code
-        with self.db.get_session() as session:
-            session.execute(text("DELETE FROM model_settings WHERE id = 999999;"))
-            session.commit()
 
     def validate_schema(self):
         """Very basic validation of 3Di schema.

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -283,7 +283,6 @@ class ModelSchema:
             )
             session.commit()
 
-
     def validate_schema(self):
         """Very basic validation of 3Di schema.
 


### PR DESCRIPTION
Since the `epsg_code` column is dropped from `model_settings` at the end of migration 230:
https://github.com/nens/threedi-schema/blob/cffc621a4595200ed768921758ad60178bc31edc/threedi_schema/migrations/versions/0230_reproject_geometries.py#L116
there is no need to preserve the original value in `model_settings`. Consequently, when overriding the `epsg_code` value in `model_settings` for the purposes of the migration, the original value in the database can be overwritten without problems.