### PR TITLE
Fix geometry for measure map

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog of threedi-schema
 ---------------------
 
 - Fix incorrect geometry in measure_location table in migration 0224
+- Correct names of several migrations
 
 
 0.300.14 (2025-03-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.15 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix incorrect geometry in measure_location table in migration 0224
 
 
 0.300.14 (2025-03-05)

--- a/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
+++ b/threedi_schema/migrations/versions/0223_upgrade_db_inflow.py
@@ -1,4 +1,4 @@
-"""Upgrade settings in schema
+"""Upgrade inflow settings
 
 Revision ID: 0223
 Revises:

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -273,19 +273,14 @@ def populate_control_measure_location():
         v2_control_measure_map;
     """
     op.execute(sa.text(query))
+    # set geometries
     query = """
-    UPDATE control_measure_location   
+    UPDATE control_measure_location
     SET geom = (
         SELECT v2_connection_nodes.the_geom
         FROM v2_connection_nodes
-        JOIN control_measure_location
-        ON v2_connection_nodes.id = control_measure_location.connection_node_id
-    )
-    WHERE EXISTS (
-        SELECT 1
-        FROM v2_connection_nodes
         WHERE v2_connection_nodes.id = control_measure_location.connection_node_id
-    );    
+    )
     """
     op.execute(sa.text(query))
 

--- a/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
+++ b/threedi_schema/migrations/versions/0224_upgrade_db_structure_control.py
@@ -1,4 +1,4 @@
-"""Upgrade settings in schema
+"""Upgrade structure control
 
 Revision ID: 0224
 Revises:

--- a/threedi_schema/migrations/versions/0226_upgrade_db_1d_1d2d.py
+++ b/threedi_schema/migrations/versions/0226_upgrade_db_1d_1d2d.py
@@ -1,4 +1,4 @@
-"""Upgrade settings in schema
+"""Upgrade 1d and 1d2d settings
 
 Revision ID: 0225
 Revises:

--- a/threedi_schema/migrations/versions/0227_fixups_structure_control.py
+++ b/threedi_schema/migrations/versions/0227_fixups_structure_control.py
@@ -1,4 +1,4 @@
-"""Upgrade settings in schema
+"""Fixups for structure control upgrade
 
 Revision ID: 0227
 Revises:

--- a/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
+++ b/threedi_schema/migrations/versions/0228_upgrade_db_1D.py
@@ -1,4 +1,4 @@
-"""Upgrade settings in schema
+"""Upgrade 1d settings
 
 Revision ID: 0225
 Revises:

--- a/threedi_schema/migrations/versions/0229_clean_up.py
+++ b/threedi_schema/migrations/versions/0229_clean_up.py
@@ -1,4 +1,4 @@
-"""
+"""Clean up some issues from migrations 222 to 228
 
 Revision ID: 022
 9Revises:

--- a/threedi_schema/migrations/versions/0300_geopackage.py
+++ b/threedi_schema/migrations/versions/0300_geopackage.py
@@ -1,4 +1,4 @@
-"""Reproject geometries to model CRS
+"""Convert to geopackage
 
 Revision ID: 0230
 Revises:


### PR DESCRIPTION
Incorrect setting of `MeasureLocation.geom` resulted in incorrect `MeasureMap.geom`; this should be fixed here.

I also modified the names of most upgrades to reflect the actual upgrade (yeah, this could have been a separate issue).