### PR TITLE
Move InvalidSRIDException to application.errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.16 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Move InvalidSRIDException to application.errors
 
 
 0.300.15 (2025-03-11)

--- a/threedi_schema/application/errors.py
+++ b/threedi_schema/application/errors.py
@@ -6,3 +6,11 @@ class MigrationMissingError(Exception):
 
 class UpgradeFailedError(Exception):
     """Raised when an upgrade() fails"""
+
+
+class InvalidSRIDException(Exception):
+    def __init__(self, epsg_code, issue=None):
+        msg = f"Cannot migrate schematisation with model_settings.epsg_code={epsg_code}"
+        if issue is not None:
+            msg += f"; {issue}"
+        super().__init__(msg)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -15,13 +15,11 @@ from osgeo import gdal, osr
 from sqlalchemy import Column, Integer, MetaData, Table, text
 from sqlalchemy.exc import IntegrityError
 
-from threedi_schema.migrations.exceptions import InvalidSRIDException
-
 from ..domain import constants, models
 from ..infrastructure.spatial_index import ensure_spatial_indexes
 from ..infrastructure.spatialite_versions import copy_models, get_spatialite_version
 from ..migrations.utils import get_model_srid
-from .errors import MigrationMissingError, UpgradeFailedError
+from .errors import InvalidSRIDException, MigrationMissingError, UpgradeFailedError
 from .upgrade_utils import setup_logging
 
 gdal.UseExceptions()

--- a/threedi_schema/migrations/exceptions.py
+++ b/threedi_schema/migrations/exceptions.py
@@ -1,6 +1,0 @@
-class InvalidSRIDException(Exception):
-    def __init__(self, epsg_code, issue=None):
-        msg = f"Cannot migrate schematisation with model_settings.epsg_code={epsg_code}"
-        if issue is not None:
-            msg += f"; {issue}"
-        super().__init__(msg)

--- a/threedi_schema/migrations/utils.py
+++ b/threedi_schema/migrations/utils.py
@@ -4,7 +4,7 @@ from typing import List
 import sqlalchemy as sa
 from alembic import op
 
-from threedi_schema.migrations.exceptions import InvalidSRIDException
+from threedi_schema.application.errors import InvalidSRIDException
 
 
 def drop_geo_table(op, table_name: str):

--- a/threedi_schema/migrations/versions/0300_geopackage.py
+++ b/threedi_schema/migrations/versions/0300_geopackage.py
@@ -11,7 +11,7 @@ import uuid
 import sqlalchemy as sa
 from alembic import op
 
-from threedi_schema.migrations.exceptions import InvalidSRIDException
+from threedi_schema.application.errors import InvalidSRIDException
 
 # revision identifiers, used by Alembic.
 revision = "0300"

--- a/threedi_schema/tests/test_migration_230_crs_reprojection.py
+++ b/threedi_schema/tests/test_migration_230_crs_reprojection.py
@@ -3,7 +3,7 @@ import sqlite3
 import pytest
 
 from threedi_schema import ModelSchema
-from threedi_schema.migrations.exceptions import InvalidSRIDException
+from threedi_schema.application.errors import InvalidSRIDException
 
 
 @pytest.mark.parametrize("epsg_code", [


### PR DESCRIPTION
`InvalidSRIDException` is used by other libraries and in `schema.py` so it makes no sense to have it limited to the migrations folder.