### PR TITLE
Fix progress handler for upgrades with 0 steps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.17 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix progress handler for upgrades with 0 steps
 
 
 0.300.16 (2025-03-11)

--- a/threedi_schema/application/upgrade_utils.py
+++ b/threedi_schema/application/upgrade_utils.py
@@ -20,7 +20,10 @@ class ProgressHandler(logging.Handler):
     def emit(self, record):
         msg = record.getMessage()
         if msg.startswith("Running upgrade"):
-            self.progress_func(100 * self.current_step / self.total_steps)
+            if self.total_steps > 0:
+                self.progress_func(100 * self.current_step / self.total_steps)
+            else:
+                self.progress_func(100)  # Assume 100% if total steps are zero
             self.current_step += 1
 
 

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -21,6 +21,16 @@ def test_progress_handler():
     assert progress_func.call_args_list == expected_calls
 
 
+def test_progress_handler_zero_steps():
+    progress_func = MagicMock()
+    mock_record = MagicMock(levelno=logging.INFO, percent=40)
+    expected_calls = 5 * [call(100)]
+    handler = upgrade_utils.ProgressHandler(progress_func, total_steps=0)
+    for _ in range(5):
+        handler.handle(mock_record)
+    assert progress_func.call_args_list == expected_calls
+
+
 @pytest.mark.parametrize(
     "target_revision, nsteps_expected", [("0226", 5), ("0200", 0), (None, 0)]
 )


### PR DESCRIPTION
Return 100 when `ProgressHandler.total_steps = 0` and add that case to the tests.