### PR TITLE
Use ogr to identify epsg for geopackages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.18 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Read EPSG code for geopackage schematisations using gdal ogr (this also works on empy schematisations)
 
 
 0.300.17 (2025-03-11)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -138,7 +138,7 @@ class ModelSchema:
             try:
                 epsg = int(epsg)
             except TypeError:
-                epsg = None
+                raise InvalidSRIDException(epsg, "the epsg_code must be an integer")
             return epsg, ""
 
     def _get_dem_epsg(self, raster_path: str = None) -> int:

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -134,8 +134,12 @@ class ModelSchema:
         else:
             datasource = ogr.Open(str(self.db.path))
             layer = datasource.GetLayerByName("connection_node")
-            srs = layer.GetSpatialRef()
-            return srs.GetAuthorityCode(None), ""
+            epsg = layer.GetSpatialRef().GetAuthorityCode(None)
+            try:
+                epsg = int(epsg)
+            except TypeError:
+                epsg = None
+            return epsg, ""
 
     def _get_dem_epsg(self, raster_path: str = None) -> int:
         """

--- a/threedi_schema/migrations/utils.py
+++ b/threedi_schema/migrations/utils.py
@@ -64,9 +64,4 @@ def get_model_srid(v2_global_settings: bool = False, session=None) -> int:
         srid = int(srid_str[0])
     except TypeError:
         raise InvalidSRIDException(srid_str[0], "the epsg_code must be an integer")
-    unit, is_projected = get_crs_info(srid)
-    if unit != "metre":
-        raise InvalidSRIDException(srid, f"the CRS must be in metres, not {unit}")
-    if not is_projected:
-        raise InvalidSRIDException(srid, "the CRS must be in projected")
     return srid

--- a/threedi_schema/migrations/utils.py
+++ b/threedi_schema/migrations/utils.py
@@ -2,7 +2,6 @@ import sqlite3
 from typing import List
 
 import sqlalchemy as sa
-from alembic import op
 
 from threedi_schema.application.errors import InvalidSRIDException
 
@@ -53,15 +52,3 @@ def get_crs_info(srid):
     return unit, is_projected
 
 
-def get_model_srid(v2_global_settings: bool = False, session=None) -> int:
-    # Note: this will not work for models which are allowed to hav
-    conn = session or op.get_bind()
-    table = "v2_global_settings" if v2_global_settings else "model_settings"
-    srid_str = conn.execute(sa.text(f"SELECT epsg_code FROM {table}")).fetchone()
-    if srid_str is None or srid_str[0] is None:
-        raise InvalidSRIDException(None, "no epsg_code is defined")
-    try:
-        srid = int(srid_str[0])
-    except TypeError:
-        raise InvalidSRIDException(srid_str[0], "the epsg_code must be an integer")
-    return srid

--- a/threedi_schema/migrations/versions/0230_reproject_geometries.py
+++ b/threedi_schema/migrations/versions/0230_reproject_geometries.py
@@ -11,7 +11,8 @@ import sqlalchemy as sa
 from alembic import op
 
 from threedi_schema.application.errors import InvalidSRIDException
-from threedi_schema.migrations.utils import get_crs_info, get_model_srid
+from threedi_schema.application.schema import get_model_srid
+from threedi_schema.migrations.utils import get_crs_info
 
 # revision identifiers, used by Alembic.
 revision = "0230"
@@ -114,7 +115,7 @@ def prep_spatialite(srid: int):
 def upgrade():
     # retrieve srid from model settings
     # raise exception if there is no srid, or if the srid is not valid
-    srid = get_model_srid()
+    srid = get_model_srid(connection=op.get_bind())
     unit, is_projected = get_crs_info(srid)
     if unit != "metre":
         raise InvalidSRIDException(srid, f"the CRS must be in metres, not {unit}")

--- a/threedi_schema/migrations/versions/0230_reproject_geometries.py
+++ b/threedi_schema/migrations/versions/0230_reproject_geometries.py
@@ -10,7 +10,8 @@ import uuid
 import sqlalchemy as sa
 from alembic import op
 
-from threedi_schema.migrations.utils import get_model_srid
+from threedi_schema.application.errors import InvalidSRIDException
+from threedi_schema.migrations.utils import get_crs_info, get_model_srid
 
 # revision identifiers, used by Alembic.
 revision = "0230"
@@ -114,6 +115,11 @@ def upgrade():
     # retrieve srid from model settings
     # raise exception if there is no srid, or if the srid is not valid
     srid = get_model_srid()
+    unit, is_projected = get_crs_info(srid)
+    if unit != "metre":
+        raise InvalidSRIDException(srid, f"the CRS must be in metres, not {unit}")
+    if not is_projected:
+        raise InvalidSRIDException(srid, "the CRS must be in projected")
     if srid is not None:
         # prepare spatialite databases
         prep_spatialite(srid)

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -373,6 +373,7 @@ def test_is_geopackage(oldest_sqlite):
     assert schema.is_geopackage
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize(
     "revision, expected_epsg_code", [("0229", None), ("0230", None), ("head", 28992)]
 )

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -350,39 +350,6 @@ def test_set_spatial_indexes(in_memory_sqlite):
     assert check_result == 1
 
 
-@pytest.mark.parametrize(
-    "revision, expected_epsg_code", [("0229", None), ("0230", None), ("head", 28992)]
-)
-def test_get_epsg_data_empty(empty_sqlite_v4, revision, expected_epsg_code):
-    schema = ModelSchema(empty_sqlite_v4)
-    schema.upgrade(
-        backup=False,
-        revision=revision,
-        upgrade_spatialite_version=False,
-        epsg_code_override=28992,
-    )
-    if expected_epsg_code is None:
-        assert schema.epsg_code is None
-    else:
-        assert schema.epsg_code == expected_epsg_code
-    assert schema.epsg_source == ""
-
-
-@pytest.mark.parametrize(
-    "revision, expected_epsg_source",
-    [
-        ("0229", "model_settings.epsg_code"),
-        ("0230", "boundary_condition_1d.geom"),
-        ("head", ""),
-    ],
-)
-def test_get_epsg_data(oldest_sqlite, revision, expected_epsg_source):
-    schema = ModelSchema(oldest_sqlite)
-    schema.upgrade(backup=False, upgrade_spatialite_version=False, revision=revision)
-    assert schema.epsg_code == 28992
-    assert schema.epsg_source == expected_epsg_source
-
-
 def test_is_spatialite(in_memory_sqlite):
     schema = ModelSchema(in_memory_sqlite)
     schema.upgrade(
@@ -406,21 +373,38 @@ def test_is_geopackage(oldest_sqlite):
     assert schema.is_geopackage
 
 
-def test_epsg_code(oldest_sqlite):
+@pytest.mark.parametrize(
+    "revision, expected_epsg_code", [("0229", None), ("0230", None), ("head", 28992)]
+)
+def test_get_epsg_data_empty(empty_sqlite_v4, revision, expected_epsg_code):
+    schema = ModelSchema(empty_sqlite_v4)
+    schema.upgrade(
+        backup=False,
+        revision=revision,
+        upgrade_spatialite_version=False,
+        epsg_code_override=28992,
+    )
+    if expected_epsg_code is None:
+        assert schema.epsg_code is None
+    else:
+        assert schema.epsg_code == expected_epsg_code
+    assert schema.epsg_source == ""
+
+
+@pytest.mark.parametrize(
+    "revision, expected_epsg_source",
+    [
+        ("0220", "v2_global_settings.epsg_code"),
+        ("0229", "model_settings.epsg_code"),
+        ("0230", "boundary_condition_1d.geom"),
+        ("head", ""),
+    ],
+)
+def test_get_epsg_data(oldest_sqlite, revision, expected_epsg_source):
     schema = ModelSchema(oldest_sqlite)
-    schema.upgrade(revision="0221", backup=False)
+    schema.upgrade(backup=False, upgrade_spatialite_version=False, revision=revision)
     assert schema.epsg_code == 28992
-    assert schema.epsg_source == "v2_global_settings.epsg_code"
-
-    schema.upgrade(revision="0229", backup=False)
-    assert schema.get_version() == 229
-    assert schema.epsg_code == 28992
-    assert schema.epsg_source == "model_settings.epsg_code"
-
-    schema.upgrade(revision="0230", backup=False)
-    assert schema.get_version() == 230
-    assert schema.epsg_code == 28992
-    assert schema.epsg_source == "boundary_condition_1d.geom"
+    assert schema.epsg_source == expected_epsg_source
 
 
 def test_epsg_code_from_dem(sqlite_with_dem):


### PR DESCRIPTION
Use ogr to find epsg for geopackage schematisations. The main advantage is that this also works with empty schematisations. I made some extra changes that were not necessary but made a lot of sense to me. I move `get_model_srid` to `schema.py` because it is used there and in a migration. As a part of that I removed the checking for projection and units from that function because that should not be part of retrieving the epsg. I also extended the tests for `get_epsg_data` and removed duplicate tests.