### PR TITLE
Fix progress tracking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.20 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix progress tracking for upgrade to be continuous
 
 
 0.300.19 (2025-03-17)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -45,12 +45,15 @@ def get_schema_version():
         return int(env.get_head_revision())
 
 
-def _upgrade_database(db, revision="head", unsafe=True, progress_func=None):
+def _upgrade_database(
+    db, revision="head", unsafe=True, progress_func=None, config=None
+):
     """Upgrade ThreediDatabase instance"""
     engine = db.engine
-    config = get_alembic_config(engine, unsafe=unsafe)
-    if progress_func is not None:
-        setup_logging(db.schema, revision, config, progress_func)
+    if config is None:
+        config = get_alembic_config(engine, unsafe=unsafe)
+    # if progress_func is not None:
+    #     setup_logging(db.schema, revision, config, progress_func)
     alembic_command.upgrade(config, revision)
 
 
@@ -276,15 +279,19 @@ class ModelSchema:
                         work_db,
                         revision=_revision,
                         unsafe=True,
-                        progress_func=progress_func,
+                        # progress_func=progress_func,
                     )
             else:
                 _upgrade_database(
                     self.db,
                     revision=_revision,
                     unsafe=False,
-                    progress_func=progress_func,
+                    # progress_func=progress_func,
                 )
+
+        if progress_func is not None:
+            config = get_alembic_config(self.db.engine, unsafe=backup)
+            setup_logging(self.db.schema, revision, config, progress_func)
 
         if epsg_code_override is not None:
             if self.get_version() is not None and self.get_version() > 229:

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -45,15 +45,11 @@ def get_schema_version():
         return int(env.get_head_revision())
 
 
-def _upgrade_database(
-    db, revision="head", unsafe=True, progress_func=None, config=None
-):
+def _upgrade_database(db, revision="head", unsafe=True, config=None):
     """Upgrade ThreediDatabase instance"""
     engine = db.engine
     if config is None:
         config = get_alembic_config(engine, unsafe=unsafe)
-    # if progress_func is not None:
-    #     setup_logging(db.schema, revision, config, progress_func)
     alembic_command.upgrade(config, revision)
 
 
@@ -279,14 +275,12 @@ class ModelSchema:
                         work_db,
                         revision=_revision,
                         unsafe=True,
-                        # progress_func=progress_func,
                     )
             else:
                 _upgrade_database(
                     self.db,
                     revision=_revision,
                     unsafe=False,
-                    # progress_func=progress_func,
                 )
 
         if progress_func is not None:

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -64,3 +64,18 @@ def test_upgrade_with_progress_func(oldest_sqlite):
         progress_func=progress_func,
     )
     assert progress_func.call_args_list == [call(0.0), call(50.0)]
+
+
+def test_upgrade_with_progress_func_latest(oldest_sqlite):
+    schema = oldest_sqlite.schema
+    progress_func = MagicMock()
+    schema.upgrade(
+        backup=False,
+        upgrade_spatialite_version=False,
+        progress_func=progress_func,
+        revision="0300",
+    )
+    progress = [call.args[0] for call in progress_func.call_args_list]
+    # ensure that the reported upgrade is increasing
+    # non-increasing progress indicates multiple initializations
+    assert all(x < y for x, y in zip(progress, progress[1:]))


### PR DESCRIPTION
Because the upgrade is split in several steps, the `_upgrade_database` is called multiple times. This results in multiple initialisations of progress tracking and the problem described [here](https://github.com/nens/threedi-results-analysis/issues/1065#issuecomment-2750438032).

To prevent this, I moved initialisation of progress tracking to `schema.upgrade` instead of `_upgrade_database` and added a test to ensure this works as expected.