### PR TITLE
Fix progress func

### DIFF
--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -20,7 +20,7 @@ from ..domain import constants, models
 from ..infrastructure.spatial_index import ensure_spatial_indexes
 from ..infrastructure.spatialite_versions import copy_models, get_spatialite_version
 from .errors import InvalidSRIDException, MigrationMissingError, UpgradeFailedError
-from .upgrade_utils import setup_logging
+from .upgrade_utils import get_upgrade_steps_count, remove_logger, setup_logging
 
 gdal.UseExceptions()
 
@@ -45,12 +45,19 @@ def get_schema_version():
         return int(env.get_head_revision())
 
 
-def _upgrade_database(db, revision="head", unsafe=True, config=None):
+def _upgrade_database(
+    db, revision="head", unsafe=True, progress_func=None, init_step=0
+):
     """Upgrade ThreediDatabase instance"""
     engine = db.engine
-    if config is None:
-        config = get_alembic_config(engine, unsafe=unsafe)
+    config = get_alembic_config(engine, unsafe=unsafe)
+    n_steps = get_upgrade_steps_count(config, db.schema.get_version(), revision)
+    if progress_func is not None:
+        handler = setup_logging(progress_func, n_steps, init_step=init_step)
     alembic_command.upgrade(config, revision)
+    if progress_func is not None:
+        remove_logger(handler)
+    return n_steps + init_step
 
 
 class GdalErrorHandler:
@@ -268,28 +275,26 @@ class ModelSchema:
                 f"Cannot upgrade from {revision=} because {self.db.path} is not a geopackage"
             )
 
-        config = None
-        if progress_func is not None:
-            config = get_alembic_config(self.db.engine, unsafe=backup)
-            setup_logging(self.db.schema, revision, config, progress_func)
-
-        def run_upgrade(_revision):
+        def run_upgrade(_revision, init_step=0):
             if backup:
                 with self.db.file_transaction() as work_db:
-                    _upgrade_database(
+                    return _upgrade_database(
                         work_db,
                         revision=_revision,
                         unsafe=True,
-                        config=config,
+                        progress_func=progress_func,
+                        init_step=init_step,
                     )
             else:
-                _upgrade_database(
+                return _upgrade_database(
                     self.db,
                     revision=_revision,
                     unsafe=False,
-                    config=config,
+                    progress_func=progress_func,
+                    init_step=init_step,
                 )
 
+        init_step = 0
         if epsg_code_override is not None:
             if self.get_version() is not None and self.get_version() > 229:
                 warnings.warn(
@@ -301,16 +306,17 @@ class ModelSchema:
                 )
             else:
                 if self.get_version() is None or self.get_version() < 229:
-                    run_upgrade("0229")
+                    init_step = run_upgrade("0229", init_step=init_step)
                 self._set_custom_epsg_code(epsg_code_override)
-                run_upgrade("0230")
+                init_step = run_upgrade("0230", init_step=init_step)
                 self._remove_temporary_model_settings()
         # First upgrade to LAST_SPTL_SCHEMA_VERSION.
         # When the requested revision <= LAST_SPTL_SCHEMA_VERSION, this is the only upgrade step
-        run_upgrade(
+        init_step = run_upgrade(
             revision
             if rev_nr <= constants.LAST_SPTL_SCHEMA_VERSION
-            else f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}"
+            else f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
+            init_step=init_step,
         )
         # only upgrade spatialite version is target revision is <= LAST_SPTL_SCHEMA_VERSION
         if rev_nr <= constants.LAST_SPTL_SCHEMA_VERSION and upgrade_spatialite_version:
@@ -318,7 +324,7 @@ class ModelSchema:
         # Finish upgrade if target revision > LAST_SPTL_SCHEMA_VERSION
         elif rev_nr > constants.LAST_SPTL_SCHEMA_VERSION:
             self.convert_to_geopackage()
-            run_upgrade(revision)
+            run_upgrade(revision, init_step=init_step)
 
     def _set_custom_epsg_code(self, custom_epsg_code: int):
         """Temporarily set epsg code in model settings for migration 230"""

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -22,6 +22,23 @@ def test_progress_handler():
     assert progress_func.call_args_list == expected_calls
 
 
+def test_progress_handler_non_zero_init():
+    progress_func = MagicMock()
+    init_step = 2
+    expected_calls = [
+        call(100 * (i + init_step) / (5 + init_step), "Running upgrade")
+        for i in range(5)
+    ]
+    mock_record = MagicMock(levelno=logging.INFO, percent=10)
+    mock_record.getMessage.return_value = "Running upgrade"
+    handler = upgrade_utils.ProgressHandler(
+        progress_func, total_steps=5, init_step=init_step
+    )
+    for _ in range(5):
+        handler.handle(mock_record)
+    assert progress_func.call_args_list == expected_calls
+
+
 def test_progress_handler_zero_steps():
     progress_func = MagicMock()
     mock_record = MagicMock(levelno=logging.INFO, percent=40)


### PR DESCRIPTION
Re-using the alembic config was not a good idea because it breaks upgrades in multiple steps :facepalm: 

For some reason, something goes wrong with the numbering of revisions. E.g. running this with 0.300.20 or 0.300.21

```python
def callback(progress, msg):
    pass

schema = ModelSchema(db)
schema.upgrade(
    backup=False,
    upgrade_spatialite_version=True,
    progress_func=callback
)
print(f'{schema.get_version()=}')
```
results in version 230. Removing the `progress_func` argument from `upgrade` fixes this issue. 

In this PR, I moved the alembic config creation back to `_upgrade_database` and added some provisions to take return the proper progess. 
* Keep track of the number of upgrade steps already performs and adapt the `ProgressHandler` to return the correct progess
* Remove the handler from the logger at the end of `_upgrade_database` to prevent adding multiple handlers

I'm not very happy with this implementation, especially the tracking op the number of upgrade steps. Would be great to discuss this.

