### PR TITLE
Delete spatialite after conversion to geopackage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.22 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix upgrade progress tracking
 
 
 0.300.21 (2025-03-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.300.22 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Delete spatialite after conversion to geopackage
 
 
 0.300.21 (2025-03-26)

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -20,7 +20,7 @@ from ..domain import constants, models
 from ..infrastructure.spatial_index import ensure_spatial_indexes
 from ..infrastructure.spatialite_versions import copy_models, get_spatialite_version
 from .errors import InvalidSRIDException, MigrationMissingError, UpgradeFailedError
-from .upgrade_utils import setup_logging
+from .upgrade_utils import get_upgrade_steps_count, remove_logger, setup_logging
 
 gdal.UseExceptions()
 
@@ -45,12 +45,19 @@ def get_schema_version():
         return int(env.get_head_revision())
 
 
-def _upgrade_database(db, revision="head", unsafe=True, config=None):
+def _upgrade_database(
+    db, revision="head", unsafe=True, progress_func=None, init_step=0
+):
     """Upgrade ThreediDatabase instance"""
     engine = db.engine
-    if config is None:
-        config = get_alembic_config(engine, unsafe=unsafe)
+    config = get_alembic_config(engine, unsafe=unsafe)
+    n_steps = get_upgrade_steps_count(config, db.schema.get_version(), revision)
+    if progress_func is not None:
+        handler = setup_logging(progress_func, n_steps, init_step=init_step)
     alembic_command.upgrade(config, revision)
+    if progress_func is not None:
+        remove_logger(handler)
+    return n_steps + init_step
 
 
 class GdalErrorHandler:
@@ -268,28 +275,26 @@ class ModelSchema:
                 f"Cannot upgrade from {revision=} because {self.db.path} is not a geopackage"
             )
 
-        config = None
-        if progress_func is not None:
-            config = get_alembic_config(self.db.engine, unsafe=backup)
-            setup_logging(self.db.schema, revision, config, progress_func)
-
-        def run_upgrade(_revision):
+        def run_upgrade(_revision, init_step=0):
             if backup:
                 with self.db.file_transaction() as work_db:
-                    _upgrade_database(
+                    return _upgrade_database(
                         work_db,
                         revision=_revision,
                         unsafe=True,
-                        config=config,
+                        progress_func=progress_func,
+                        init_step=init_step,
                     )
             else:
-                _upgrade_database(
+                return _upgrade_database(
                     self.db,
                     revision=_revision,
                     unsafe=False,
-                    config=config,
+                    progress_func=progress_func,
+                    init_step=init_step,
                 )
 
+        init_step = 0
         if epsg_code_override is not None:
             if self.get_version() is not None and self.get_version() > 229:
                 warnings.warn(
@@ -301,16 +306,17 @@ class ModelSchema:
                 )
             else:
                 if self.get_version() is None or self.get_version() < 229:
-                    run_upgrade("0229")
+                    init_step = run_upgrade("0229", init_step=init_step)
                 self._set_custom_epsg_code(epsg_code_override)
-                run_upgrade("0230")
+                init_step = run_upgrade("0230", init_step=init_step)
                 self._remove_temporary_model_settings()
         # First upgrade to LAST_SPTL_SCHEMA_VERSION.
         # When the requested revision <= LAST_SPTL_SCHEMA_VERSION, this is the only upgrade step
-        run_upgrade(
+        init_step = run_upgrade(
             revision
             if rev_nr <= constants.LAST_SPTL_SCHEMA_VERSION
-            else f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}"
+            else f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
+            init_step=init_step,
         )
         # only upgrade spatialite version is target revision is <= LAST_SPTL_SCHEMA_VERSION
         if rev_nr <= constants.LAST_SPTL_SCHEMA_VERSION and upgrade_spatialite_version:
@@ -318,7 +324,7 @@ class ModelSchema:
         # Finish upgrade if target revision > LAST_SPTL_SCHEMA_VERSION
         elif rev_nr > constants.LAST_SPTL_SCHEMA_VERSION:
             self.convert_to_geopackage()
-            run_upgrade(revision)
+            run_upgrade(revision, init_step=init_step)
 
     def _set_custom_epsg_code(self, custom_epsg_code: int):
         """Temporarily set epsg code in model settings for migration 230"""

--- a/threedi_schema/application/upgrade_utils.py
+++ b/threedi_schema/application/upgrade_utils.py
@@ -11,16 +11,15 @@ else:
 
 
 class ProgressHandler(logging.Handler):
-    def __init__(self, progress_func, total_steps, init_step=0):
+    def __init__(self, progress_func, total_steps):
         super().__init__()
         self.progress_func = progress_func
-        self.total_steps = total_steps + init_step
-        self.current_step = init_step
+        self.total_steps = total_steps
+        self.current_step = 0
 
     def emit(self, record):
         msg = record.getMessage()
         if msg.startswith("Running upgrade"):
-            print(f"{self.total_steps=}; {self.current_step=}")
             if self.total_steps > 0:
                 self.progress_func(100 * self.current_step / self.total_steps, msg)
             else:
@@ -63,9 +62,7 @@ def get_upgrade_steps_count(
     return len(list(revisions)) + offset
 
 
-def setup_logging(
-    progress_func: Callable[[float, str], None], n_steps: int, init_step: int
-):
+def setup_logging(progress_func: Callable[[float, str], None], n_steps: int):
     """
     Set up logging for schematisation upgrade
 
@@ -77,11 +74,6 @@ def setup_logging(
     """
     logger = logging.getLogger("alembic.runtime.migration")
     logger.setLevel(logging.INFO)
-    handler = ProgressHandler(progress_func, total_steps=n_steps, init_step=init_step)
+    handler = ProgressHandler(progress_func, total_steps=n_steps)
     logger.addHandler(handler)
     return handler
-
-
-def remove_logger(handler: ProgressHandler):
-    logger = logging.getLogger("alembic.runtime.migration")
-    logger.removeHandler(handler)

--- a/threedi_schema/tests/test_gpkg.py
+++ b/threedi_schema/tests/test_gpkg.py
@@ -6,18 +6,21 @@ from sqlalchemy import text
 from threedi_schema.domain import constants
 
 
-@pytest.mark.parametrize("upgrade_spatialite", [True, False])
-def test_convert_to_geopackage(oldest_sqlite, upgrade_spatialite):
+@pytest.mark.parametrize(
+    "upgrade_spatialite, delete_spatialite", [[True, True], [False, False]]
+)
+def test_convert_to_geopackage(oldest_sqlite, upgrade_spatialite, delete_spatialite):
     # if upgrade_spatialite:
     oldest_sqlite.schema.upgrade(
         upgrade_spatialite_version=upgrade_spatialite,
         revision=f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
     )
     old_path = Path(oldest_sqlite.path)
-    oldest_sqlite.schema.convert_to_geopackage()
+    oldest_sqlite.schema.convert_to_geopackage(delete_spatialite=delete_spatialite)
     # Ensure that after the conversion the geopackage is used
     assert oldest_sqlite.path.suffix == ".gpkg"
-    assert not old_path.exists()
+    if delete_spatialite:
+        assert not old_path.exists()
     assert not oldest_sqlite.schema.is_spatialite
     assert oldest_sqlite.schema.is_geopackage
 

--- a/threedi_schema/tests/test_gpkg.py
+++ b/threedi_schema/tests/test_gpkg.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from sqlalchemy import text
 
@@ -11,10 +13,11 @@ def test_convert_to_geopackage(oldest_sqlite, upgrade_spatialite):
         upgrade_spatialite_version=upgrade_spatialite,
         revision=f"{constants.LAST_SPTL_SCHEMA_VERSION:04d}",
     )
-
+    old_path = Path(oldest_sqlite.path)
     oldest_sqlite.schema.convert_to_geopackage()
     # Ensure that after the conversion the geopackage is used
     assert oldest_sqlite.path.suffix == ".gpkg"
+    assert not old_path.exists()
     assert not oldest_sqlite.schema.is_spatialite
     assert oldest_sqlite.schema.is_geopackage
 

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -254,6 +255,16 @@ def test_upgrade_south_not_latest_errors(in_memory_sqlite):
     ):
         with pytest.raises(errors.MigrationMissingError):
             schema.upgrade(backup=False, upgrade_spatialite_version=False)
+
+
+@pytest.mark.parametrize("keep_spatialite", [True, False])
+def test_upgrade_keep_sqlite(south_latest_sqlite, keep_spatialite):
+    old_path = Path(south_latest_sqlite.path)
+    schema = ModelSchema(south_latest_sqlite)
+    schema.upgrade(
+        keep_spatialite=keep_spatialite, revision="0300", epsg_code_override=28992
+    )
+    assert old_path.exists() is keep_spatialite
 
 
 def test_upgrade_with_backup(south_latest_sqlite):

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -56,7 +56,6 @@ def test_get_upgrade_steps_count_pre_200(oldest_sqlite):
     assert nsteps == 27
 
 
-@pytest.mark.skip(reason="This test fails due to issue 221")
 def test_upgrade_with_progress_func(oldest_sqlite):
     schema = oldest_sqlite.schema
     progress_func = MagicMock()
@@ -78,7 +77,6 @@ def test_upgrade_with_progress_func(oldest_sqlite):
     ]
 
 
-@pytest.mark.skip(reason="This test fails due to issue 221")
 def test_upgrade_with_progress_func_latest(oldest_sqlite):
     schema = oldest_sqlite.schema
     progress_func = MagicMock()

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -56,6 +56,7 @@ def test_get_upgrade_steps_count_pre_200(oldest_sqlite):
     assert nsteps == 27
 
 
+@pytest.mark.skip(reason="This test fails due to issue 221")
 def test_upgrade_with_progress_func(oldest_sqlite):
     schema = oldest_sqlite.schema
     progress_func = MagicMock()
@@ -77,6 +78,7 @@ def test_upgrade_with_progress_func(oldest_sqlite):
     ]
 
 
+@pytest.mark.skip(reason="This test fails due to issue 221")
 def test_upgrade_with_progress_func_latest(oldest_sqlite):
     schema = oldest_sqlite.schema
     progress_func = MagicMock()

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -22,23 +22,6 @@ def test_progress_handler():
     assert progress_func.call_args_list == expected_calls
 
 
-def test_progress_handler_non_zero_init():
-    progress_func = MagicMock()
-    init_step = 2
-    expected_calls = [
-        call(100 * (i + init_step) / (5 + init_step), "Running upgrade")
-        for i in range(5)
-    ]
-    mock_record = MagicMock(levelno=logging.INFO, percent=10)
-    mock_record.getMessage.return_value = "Running upgrade"
-    handler = upgrade_utils.ProgressHandler(
-        progress_func, total_steps=5, init_step=init_step
-    )
-    for _ in range(5):
-        handler.handle(mock_record)
-    assert progress_func.call_args_list == expected_calls
-
-
 def test_progress_handler_zero_steps():
     progress_func = MagicMock()
     mock_record = MagicMock(levelno=logging.INFO, percent=40)

--- a/threedi_schema/tests/test_upgrade_utils.py
+++ b/threedi_schema/tests/test_upgrade_utils.py
@@ -22,6 +22,23 @@ def test_progress_handler():
     assert progress_func.call_args_list == expected_calls
 
 
+def test_progress_handler_non_zero_init():
+    progress_func = MagicMock()
+    init_step = 2
+    expected_calls = [
+        call(100 * (i + init_step) / (5 + init_step), "Running upgrade")
+        for i in range(5)
+    ]
+    mock_record = MagicMock(levelno=logging.INFO, percent=10)
+    mock_record.getMessage.return_value = "Running upgrade"
+    handler = upgrade_utils.ProgressHandler(
+        progress_func, total_steps=5, init_step=init_step
+    )
+    for _ in range(5):
+        handler.handle(mock_record)
+    assert progress_func.call_args_list == expected_calls
+
+
 def test_progress_handler_zero_steps():
     progress_func = MagicMock()
     mock_record = MagicMock(levelno=logging.INFO, percent=40)


### PR DESCRIPTION
Oops, merged branch https://github.com/nens/threedi-schema/pull/223 in this. But that's already in master so doesn't really matter.

Added option `keep_spatialite` to `upgrade` and `delete_spatialite` to `convert_to_geopackage`. By default the spatialite is removed at the end of the geopackage conversion but only if:
* nothing was raised
* `schema.is_geopackage=True` and `schema.is_spatialite=False`