### PR TITLE
Extend schema validation with validation of the db structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ coverage.xml
 
 # Docker
 docker-compose.override.yml
+
+# AI
+.minispec
+AGENTS.md

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedi-schema
 0.302.1 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Extend validation method to check wether defined tables and columns are present (nens/rana#4189)
 
 
 0.302.0 (2026-04-10)

--- a/threedi_schema/application/errors.py
+++ b/threedi_schema/application/errors.py
@@ -20,7 +20,7 @@ class SchemaStructureError(Exception):
     """Raised when expected tables or columns are missing from the database."""
 
     def __init__(self, missing_tables=None, missing_columns=None):
-        parts = ["Database schema structure is incomplete."]
+        parts = ["Database schema structure is invalid."]
 
         if missing_tables:
             parts.append(f"\nMissing tables ({len(missing_tables)}):")
@@ -32,7 +32,5 @@ class SchemaStructureError(Exception):
             for table in sorted(missing_columns.keys()):
                 cols = sorted(missing_columns[table])
                 parts.append(f"\n\t- {table}: {', '.join(cols)}")
-
-        parts.append("\nThe database may need to be upgraded or repaired.")
 
         super().__init__("".join(parts))

--- a/threedi_schema/application/errors.py
+++ b/threedi_schema/application/errors.py
@@ -14,3 +14,30 @@ class InvalidSRIDException(Exception):
         if issue is not None:
             msg += f"; {issue}"
         super().__init__(msg)
+
+
+class SchemaStructureError(Exception):
+    """Raised when expected tables or columns are missing from the database.
+
+    Attributes:
+        missing_tables: List of table names that are missing from the database.
+        missing_columns: Dict mapping table name to list of missing column names.
+    """
+
+    def __init__(self, missing_tables=None, missing_columns=None):
+        parts = ["Database schema structure is incomplete."]
+
+        if missing_tables:
+            parts.append(f"\nMissing tables ({len(missing_tables)}):")
+            for table in sorted(missing_tables):
+                parts.append(f"\n  - {table}")
+
+        if missing_columns:
+            parts.append(f"\nMissing columns in {len(missing_columns)} table(s):")
+            for table in sorted(missing_columns.keys()):
+                cols = sorted(missing_columns[table])
+                parts.append(f"\n  - {table}: {', '.join(cols)}")
+
+        parts.append("\nThe database may need to be upgraded or repaired.")
+
+        super().__init__("".join(parts))

--- a/threedi_schema/application/errors.py
+++ b/threedi_schema/application/errors.py
@@ -30,13 +30,13 @@ class SchemaStructureError(Exception):
         if missing_tables:
             parts.append(f"\nMissing tables ({len(missing_tables)}):")
             for table in sorted(missing_tables):
-                parts.append(f"\n  - {table}")
+                parts.append(f"\n\t- {table}")
 
         if missing_columns:
             parts.append(f"\nMissing columns in {len(missing_columns)} table(s):")
             for table in sorted(missing_columns.keys()):
                 cols = sorted(missing_columns[table])
-                parts.append(f"\n  - {table}: {', '.join(cols)}")
+                parts.append(f"\n\t- {table}: {', '.join(cols)}")
 
         parts.append("\nThe database may need to be upgraded or repaired.")
 

--- a/threedi_schema/application/errors.py
+++ b/threedi_schema/application/errors.py
@@ -17,12 +17,7 @@ class InvalidSRIDException(Exception):
 
 
 class SchemaStructureError(Exception):
-    """Raised when expected tables or columns are missing from the database.
-
-    Attributes:
-        missing_tables: List of table names that are missing from the database.
-        missing_columns: Dict mapping table name to list of missing column names.
-    """
+    """Raised when expected tables or columns are missing from the database."""
 
     def __init__(self, missing_tables=None, missing_columns=None):
         parts = ["Database schema structure is incomplete."]

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -14,11 +14,16 @@ from alembic.script import ScriptDirectory
 from geoalchemy2.admin.dialects.geopackage import create_spatial_ref_sys_view
 from geoalchemy2.functions import ST_SRID
 from osgeo import gdal, ogr, osr
-from sqlalchemy import Column, Integer, MetaData, Table, text
+from sqlalchemy import Column, inspect, Integer, MetaData, Table, text
 
 from ..domain import constants, models
 from ..infrastructure.spatial_index import ensure_spatial_indexes
-from .errors import InvalidSRIDException, MigrationMissingError, UpgradeFailedError
+from .errors import (
+    InvalidSRIDException,
+    MigrationMissingError,
+    SchemaStructureError,
+    UpgradeFailedError,
+)
 from .upgrade_utils import get_upgrade_steps_count, setup_logging
 
 gdal.UseExceptions()
@@ -337,14 +342,14 @@ class ModelSchema:
             session.commit()
 
     def validate_schema(self):
-        """Very basic validation of 3Di schema.
+        """Validate 3Di schema version and structure.
 
-        Check that the database has the latest migration applied. If the
-        latest migrations is applied, we assume the database also contains all
-        tables and columns defined in threedi_model.models.py.
+        Check that the database has the latest migration applied and that all
+        expected tables and columns are present.
 
-        :return: True if the threedi_db schema is valid, raises an error otherwise.
-        :raise MigrationMissingError, MigrationTooHighError
+        :return: True if the schema is valid.
+        :raise MigrationMissingError: if the migration version is too low.
+        :raise SchemaStructureError: if expected tables or columns are missing.
         """
         version = self.get_version()
         schema_version = get_schema_version()
@@ -360,6 +365,29 @@ class ModelSchema:
                 f"({version} > {schema_version}). This may lead to unexpected "
                 f"results. "
             )
+
+        inspector = inspect(self.db.engine)
+        existing_tables = set(inspector.get_table_names())
+        missing_tables = []
+        missing_columns = {}
+
+        for model in self.declared_models:
+            table_name = model.__tablename__
+            if table_name not in existing_tables:
+                missing_tables.append(table_name)
+                continue
+            existing_cols = {col["name"] for col in inspector.get_columns(table_name)}
+            expected_cols = {col.name for col in model.__table__.columns}
+            missing = sorted(expected_cols - existing_cols)
+            if missing:
+                missing_columns[table_name] = missing
+
+        if missing_tables or missing_columns:
+            raise SchemaStructureError(
+                missing_tables=missing_tables,
+                missing_columns=missing_columns,
+            )
+
         return True
 
     def set_spatial_indexes(self):

--- a/threedi_schema/application/schema.py
+++ b/threedi_schema/application/schema.py
@@ -365,6 +365,7 @@ class ModelSchema:
                 f"({version} > {schema_version}). This may lead to unexpected "
                 f"results. "
             )
+            return True
 
         inspector = inspect(self.db.engine)
         existing_tables = set(inspector.get_table_names())

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -391,9 +391,9 @@ class TestSchemaStructureValidation:
         schema = ModelSchema(sqlite_latest)
         with sqlite_latest.get_session() as session:
             session.execute(text("DROP TABLE connection_node"))
-            session.execute(text(
-                "CREATE TABLE connection_node (id INTEGER PRIMARY KEY, code TEXT)"
-            ))
+            session.execute(
+                text("CREATE TABLE connection_node (id INTEGER PRIMARY KEY, code TEXT)")
+            )
             session.commit()
         with pytest.raises(errors.SchemaStructureError) as exc_info:
             schema.validate_schema()

--- a/threedi_schema/tests/test_schema.py
+++ b/threedi_schema/tests/test_schema.py
@@ -369,3 +369,33 @@ def test_epsg_code_from_dem(sqlite_with_dem):
     assert schema._get_dem_epsg() == 28991
     schema.upgrade(epsg_code_override=schema._get_dem_epsg())
     assert schema._get_dem_epsg() == 28991
+
+
+class TestSchemaStructureValidation:
+    """Tests for structure validation in ModelSchema.validate_schema()."""
+
+    def test_complete_schema_passes(self, sqlite_latest):
+        schema = ModelSchema(sqlite_latest)
+        schema.validate_schema()  # should not raise
+
+    def test_missing_table_raises(self, sqlite_latest):
+        schema = ModelSchema(sqlite_latest)
+        with sqlite_latest.get_session() as session:
+            session.execute(text("DROP TABLE connection_node"))
+            session.commit()
+        with pytest.raises(errors.SchemaStructureError) as exc_info:
+            schema.validate_schema()
+        assert "connection_node" in str(exc_info.value)
+
+    def test_missing_column_raises(self, sqlite_latest):
+        schema = ModelSchema(sqlite_latest)
+        with sqlite_latest.get_session() as session:
+            session.execute(text("DROP TABLE connection_node"))
+            session.execute(text(
+                "CREATE TABLE connection_node (id INTEGER PRIMARY KEY, code TEXT)"
+            ))
+            session.commit()
+        with pytest.raises(errors.SchemaStructureError) as exc_info:
+            schema.validate_schema()
+        assert "connection_node" in str(exc_info.value)
+        assert "storage_area" in str(exc_info.value)


### PR DESCRIPTION
Extend `ModelSchema.validate_schema` to ensure all tables and columns are actually present. Invalid models will raise a `SchemaStructureError`.

## Related:
- threedi-modelchecker: catch and handle `SchemaStructureError`
- rana-qgis-plugin catch and handle `SchemaStructureError` when calling `validate_schema` in `upload_wizard.py` and 'utils_ui.py`
- threedi-results-analysis: catch and handle `SchemaStructureError`

Closes nens/rana#4189